### PR TITLE
Add concise docstrings to core modules

### DIFF
--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -9,6 +9,19 @@ from jsonschema import validate, ValidationError
 
 
 def load_schema_and_tasks(path: Path):
+    """Return JSON schema and task list from ``tasks.yml``.
+
+    Parameters
+    ----------
+    path:
+        Location of the ``tasks.yml`` file.
+
+    Returns
+    -------
+    tuple
+        Parsed JSON schema and list of task dictionaries. Exits with code
+        ``2`` if the file cannot be read or ``1`` for parsing errors.
+    """
     try:
         text = path.read_text()
     except OSError as exc:
@@ -45,6 +58,11 @@ def load_schema_and_tasks(path: Path):
 
 
 def main():
+    """Bootstrap the system by validating ``tasks.yml``.
+
+    Returns exit codes ``0`` on success, ``1`` for validation errors and ``2``
+    for filesystem issues.
+    """
     timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
     logfile = Path("logs") / f"bootstrap-{timestamp}.log"
     try:

--- a/core/cli.py
+++ b/core/cli.py
@@ -6,6 +6,7 @@ from .memory import Memory
 
 
 def build_parser() -> argparse.ArgumentParser:
+    """Create and return the command line parser."""
     parser = argparse.ArgumentParser(description="AI-SWE orchestration CLI")
     parser.add_argument(
         "--memory",
@@ -16,6 +17,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv=None):
+    """Run the orchestrator using arguments from ``argv``."""
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/core/memory.py
+++ b/core/memory.py
@@ -6,15 +6,24 @@ class Memory:
     """Persist simple JSON state to disk."""
 
     def __init__(self, path: Path):
+        """Initialize the memory store.
+
+        Parameters
+        ----------
+        path:
+            File location for the JSON state.
+        """
         self.path = Path(path)
 
     def load(self):
+        """Load and return persisted state or an empty dict."""
         if not self.path.exists():
             return {}
         with self.path.open("r") as fh:
             return json.load(fh)
 
     def save(self, data):
+        """Persist ``data`` to disk as JSON."""
         self.path.parent.mkdir(parents=True, exist_ok=True)
         with self.path.open("w") as fh:
             json.dump(data, fh)

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -2,13 +2,22 @@ class Orchestrator:
     """Coordinate planner, executor, auditor and persistence."""
 
     def __init__(self, planner, executor, auditor, memory):
+        """Create a new orchestrator instance.
+
+        Parameters
+        ----------
+        planner, executor, auditor:
+            Components responsible for planning, execution and auditing.
+        memory:
+            ``Memory`` instance used for persistence.
+        """
         self.planner = planner
         self.executor = executor
         self.auditor = auditor
         self.memory = memory
 
     def run(self):
-        """Main entry point for orchestration loop."""
+        """Execute a single orchestration cycle and return ``True``."""
         print("Orchestrator running")
         # Future logic will coordinate components using memory
         return True


### PR DESCRIPTION
## Summary
- document `load_schema_and_tasks()` and `main()` in `core/bootstrap.py`
- add docstrings for CLI helpers
- clarify persistence interfaces
- expand orchestrator docstrings

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68525b2708e0832a93b587835da23514