### PR TITLE
Add Reflector component for self-improvement

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -96,6 +96,33 @@ class SelfAuditor:
         are exceeded."""
 ```
 
+### Reflector
+Coordinates a self-improvement cycle by scanning the repository and appending
+new tasks when code complexity exceeds a threshold.
+
+```python
+from pathlib import Path
+import yaml
+from radon.complexity import cc_visit
+
+
+class Reflector:
+    def __init__(self, tasks_path: Path, threshold: int = 10, paths=None):
+        self.tasks_path = Path(tasks_path)
+        self.threshold = threshold
+        self.paths = [Path(p) for p in paths] if paths else None
+
+    def run_cycle(self):
+        files = self.paths or list(Path('.').rglob('*.py'))
+        metrics = self._analyze(files)
+        tasks = self._load_tasks()
+        new = self._decide(metrics, tasks)
+        if new:
+            tasks.extend(new)
+            self._save_tasks(tasks)
+        return new
+```
+
 ## Bootstrapping Flow
 ```mermaid
 flowchart TD

--- a/core/reflector.py
+++ b/core/reflector.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+from radon.complexity import cc_visit
+
+
+class Reflector:
+    """Perform a simple self-improvement cycle."""
+
+    def __init__(self, tasks_path: Path | str = Path("tasks.yml"), threshold: int = 10, paths=None):
+        self.tasks_path = Path(tasks_path)
+        self.threshold = threshold
+        self.paths = [Path(p) for p in paths] if paths else None
+
+    # internal helpers
+    def _load_tasks(self):
+        if not self.tasks_path.exists():
+            return []
+        with self.tasks_path.open("r") as fh:
+            return yaml.safe_load(fh) or []
+
+    def _save_tasks(self, tasks):
+        with self.tasks_path.open("w") as fh:
+            yaml.safe_dump(tasks, fh, sort_keys=False)
+
+    def _next_id(self, tasks):
+        return max((t["id"] for t in tasks), default=0) + 1
+
+    def _analyze(self, files):
+        metrics = {}
+        for path in files:
+            try:
+                text = Path(path).read_text()
+            except OSError:
+                continue
+            blocks = cc_visit(text)
+            total = sum(b.complexity for b in blocks)
+            metrics[str(path)] = total
+        return metrics
+
+    def _decide(self, metrics, tasks):
+        new_tasks = []
+        next_id = self._next_id(tasks)
+        for path, score in metrics.items():
+            if score > self.threshold:
+                new_tasks.append({
+                    "id": next_id,
+                    "description": f"Refactor {path} complexity {score}",
+                    "component": "core",
+                    "dependencies": [],
+                    "priority": 3,
+                    "status": "pending",
+                })
+                next_id += 1
+        return new_tasks
+
+    def run_cycle(self):
+        files = self.paths or list(Path('.').rglob('*.py'))
+        metrics = self._analyze(files)
+        tasks = self._load_tasks()
+        new_tasks = self._decide(metrics, tasks)
+        if new_tasks:
+            tasks.extend(new_tasks)
+            self._save_tasks(tasks)
+        return new_tasks

--- a/tasks.yml
+++ b/tasks.yml
@@ -75,7 +75,7 @@
   component: auditor
   dependencies: [9]
   priority: 2
-  status: pending
+  status: done
 - id: 13
   description: Implement analyze() in SelfAuditor using radon APIs
   component: auditor
@@ -105,4 +105,18 @@
   component: orchestrator
   dependencies: [9]
   priority: 2
+  status: pending
+
+# Reflective loop enhancements
+- id: 16
+  description: Introduce Reflector component to automate self-improvement cycles
+  component: reflector
+  dependencies: []
+  priority: 2
+  status: pending
+- id: 17
+  description: Add unit test for Reflector run_cycle
+  component: testing
+  dependencies: [16]
+  priority: 3
   status: pending

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+import yaml
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.reflector import Reflector
+
+
+def test_reflector_creates_task(tmp_path):
+    tasks_file = tmp_path / "tasks.yml"
+    tasks_file.write_text("- id: 1\n  description: base\n  component: core\n  dependencies: []\n  priority: 1\n  status: pending\n")
+    code_file = tmp_path / "complex.py"
+    code_file.write_text("""\
+def func(x):
+    if x > 0:
+        if x > 1:
+            return 1
+        else:
+            return 2
+    else:
+        return 3
+""")
+    refl = Reflector(tasks_path=tasks_file, threshold=1, paths=[code_file])
+    new_tasks = refl.run_cycle()
+    assert new_tasks
+    tasks = yaml.safe_load(tasks_file.read_text())
+    assert len(tasks) == 2
+    assert tasks[-1]["description"].startswith("Refactor")


### PR DESCRIPTION
## Summary
- mark radon dependency task complete
- plan new tasks for Reflector component
- add Reflector class to create refactor tasks based on complexity
- document Reflector in architecture
- test Reflector behavior

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68526484e800832ab6fbfdf99e61a8e9