### PR TITLE
Add SelfAuditor research and planning

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,11 +77,12 @@ class Executor:
 ```
 
 ### SelfAuditor
-Inspects code quality metrics and generates refactor tasks when complexity is
-high. The initial implementation relies on **radon** to calculate cyclomatic
-complexity for Python modules. Historical tracking with **wily** will be added
-later. The auditor never mutates code directly; instead it returns a list of
-new tasks for the `Planner` to merge into `tasks.yml`.
+Evaluates code metrics and decides when refactors are required. Metrics are
+obtained via **radon** (cyclomatic complexity and maintainability index) and,
+optionally, **wily** for historical trends. The auditor never changes source
+files itself. Instead it returns task dictionaries that the `Planner` appends to
+`tasks.yml`. Each task describes the module, offending score and a brief
+refactor suggestion.
 
 ```python
 class SelfAuditor:
@@ -89,12 +90,16 @@ class SelfAuditor:
         self.threshold = threshold
 
     def analyze(self, paths):
-        """Return cyclomatic complexity metrics for ``paths`` using radon."""
+        """Return a mapping of file paths to radon metrics."""
 
     def audit(self, tasks):
-        """Inspect complexity and return new task dictionaries when limits
-        are exceeded."""
+        """Return new task entries when complexity exceeds ``self.threshold``."""
 ```
+
+After each execution cycle the `Orchestrator` calls `SelfAuditor.audit()` with
+the current task list. Any returned entries are appended through the `Planner`,
+which rewrites `tasks.yml` so that future iterations can schedule the
+recommended refactors.
 
 ### Reflector
 Coordinates a self-improvement cycle by scanning the repository and appending

--- a/research/RB-001_Code_Quality_Analysis.md
+++ b/research/RB-001_Code_Quality_Analysis.md
@@ -17,6 +17,11 @@
 - Detects dead code, unused variables and potential errors beyond complexity metrics.
 - Can be slower but offers comprehensive quality checks.
 
+### Flake8 7.0.0
+- Combines `pyflakes`, `pycodestyle` and McCabe complexity checks.
+- Fast linter with plugin ecosystem for additional rules.
+- Useful for enforcing style and catching simple errors.
+
 ## Proposed Heuristic
 - Run Radon on modified modules after each orchestration cycle.
 - If any function has CC > **15** or module MI < **60**, flag it for refactoring.
@@ -26,4 +31,12 @@
 - The SelfAuditor should **not** modify code directly.
 - When thresholds are exceeded, it appends a new task entry to `tasks.yml` describing the recommended refactor.
 - Planner then incorporates these tasks into future iterations.
+
+## Refactoring Patterns
+Automatable patterns that can reduce complexity include:
+- **Extract Method** – split large functions into smaller ones.
+- **Introduce Parameter Object** – replace long parameter lists with a data class.
+- **Replace Conditional with Polymorphism** – move conditional logic into separate classes when applicable.
+
+In summary, the SelfAuditor should rely on Radon for real-time metrics, optionally consult Wily for trends, and create `tasks.yml` entries proposing refactors whenever thresholds are breached. Automatic code rewriting is deferred to the Planner and Executor to keep the auditor lightweight and safe.
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -154,3 +154,21 @@
   dependencies: []
   priority: 3
   status: done
+- id: 24
+  description: Implement SelfAuditor service producing refactor tasks
+  component: auditor
+  dependencies: []
+  priority: 2
+  status: pending
+- id: 25
+  description: Expose SelfAuditor command line interface for manual audits
+  component: cli
+  dependencies: [24]
+  priority: 3
+  status: pending
+- id: 26
+  description: Planner merges SelfAuditor generated tasks into tasks.yml
+  component: planner
+  dependencies: [24]
+  priority: 2
+  status: pending


### PR DESCRIPTION
## Summary
- expand research brief with code quality library comparison and proposed heuristics
- describe SelfAuditor integration in ARCHITECTURE
- add planning epics for SelfAuditor

## Testing
- `pip install -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68527bf9d768832ab5ca5015559c30a9