### PR TITLE
Add module docstrings and begin CI tasks

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,2 @@
+"""Core package containing orchestrator components."""
+

--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -1,3 +1,5 @@
+"""Bootstrap the AI-SWA environment and validate tasks."""
+
 import json
 import logging
 import sys

--- a/core/cli.py
+++ b/core/cli.py
@@ -1,3 +1,5 @@
+"""Command line interface for AI-SWA orchestration."""
+
 import argparse
 from pathlib import Path
 

--- a/core/executor.py
+++ b/core/executor.py
@@ -1,3 +1,6 @@
+"""Execution component running discrete tasks."""
+
+
 class Executor:
     """Execute planned tasks."""
 

--- a/core/memory.py
+++ b/core/memory.py
@@ -1,3 +1,5 @@
+"""Persistent storage utility for tasks and metadata."""
+
 from pathlib import Path
 import json
 

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -1,3 +1,6 @@
+"""High-level coordinator for planner, executor and auditor."""
+
+
 class Orchestrator:
     """Coordinate planner, executor, auditor and persistence."""
 

--- a/core/planner.py
+++ b/core/planner.py
@@ -1,3 +1,6 @@
+"""Simple decision maker selecting the next task."""
+
+
 class Planner:
     """Determine the next action based on available tasks."""
 

--- a/core/reflector.py
+++ b/core/reflector.py
@@ -1,3 +1,5 @@
+"""Provide reflection utilities for self-improvement loops."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/core/self_auditor.py
+++ b/core/self_auditor.py
@@ -1,3 +1,6 @@
+"""Utility to inspect executed tasks and gather metrics."""
+
+
 class SelfAuditor:
     """Inspect results of executed tasks."""
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -154,3 +154,21 @@
   dependencies: []
   priority: 3
   status: done
+- id: 24
+  description: Add missing module docstrings across core modules
+  component: docs
+  dependencies: []
+  priority: 2
+  status: done
+- id: 25
+  description: Set up GitHub Actions workflow to run pytest and pylint
+  component: ci
+  dependencies: []
+  priority: 2
+  status: pending
+- id: 26
+  description: Configure flake8 and pre-commit for code style enforcement
+  component: deps
+  dependencies: []
+  priority: 3
+  status: pending


### PR DESCRIPTION
## Summary
- add task 24 to tasks.yml and mark it complete
- document modules across `core` package with module level docstrings

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_685279285440832a9bd923d43b37b176