### PR TITLE
Implement tasks 27-29

### DIFF
--- a/core/self_auditor.py
+++ b/core/self_auditor.py
@@ -1,8 +1,32 @@
 """Utility to inspect executed tasks and gather metrics."""
 
+from pathlib import Path
+
+from radon.complexity import cc_visit
+from radon.metrics import mi_visit
+
 
 class SelfAuditor:
     """Inspect results of executed tasks."""
+
+    def analyze(self, root: str | Path = "core"):
+        """Return maintainability metrics for Python files under ``root``."""
+        root_path = Path(root)
+        results: dict[str, dict[str, float]] = {}
+        for pyfile in root_path.rglob("*.py"):
+            try:
+                code = pyfile.read_text()
+            except OSError:
+                continue
+            mi = mi_visit(code, False)
+            blocks = cc_visit(code)
+            avg_cc = (
+                sum(b.complexity for b in blocks) / len(blocks)
+                if blocks
+                else 0.0
+            )
+            results[str(pyfile)] = {"mi": mi, "avg_cc": avg_cc}
+        return results
 
     def audit(self):
         """Perform an audit step."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ PyYAML==6.0.1
 pytest==7.4.0
 jsonschema==4.21.0
 radon==5.1.0
+wily==1.25.0
 pylint==3.3.7

--- a/tasks.yml
+++ b/tasks.yml
@@ -172,3 +172,21 @@
   dependencies: []
   priority: 3
   status: pending
+- id: 27
+  description: Pin wily dependency in requirements.txt
+  component: deps
+  dependencies: []
+  priority: 2
+  status: done
+- id: 28
+  description: Implement analyze() in SelfAuditor using radon
+  component: code
+  dependencies: [13]
+  priority: 3
+  status: done
+- id: 29
+  description: Add tests covering SelfAuditor.analyze and audit
+  component: tests
+  dependencies: [28]
+  priority: 3
+  status: done

--- a/tests/test_self_auditor.py
+++ b/tests/test_self_auditor.py
@@ -10,3 +10,13 @@ def test_self_auditor_audit():
     auditor = SelfAuditor()
     result = auditor.audit()
     assert result is None
+
+
+def test_self_auditor_analyze(tmp_path):
+    target = tmp_path / "sample.py"
+    target.write_text("def foo():\n    return 1\n")
+    auditor = SelfAuditor()
+    metrics = auditor.analyze(tmp_path)
+    key = str(target)
+    assert key in metrics
+    assert metrics[key]["mi"] > 0


### PR DESCRIPTION
## Summary
- pin `wily` dependency for complexity history tracking
- implement `SelfAuditor.analyze` using radon to compute metrics
- add tests for the new analysis behavior
- record completed tasks

## Testing
- `pytest --maxfail=1 --disable-warnings -q`
- `pylint core/self_auditor.py`

------
https://chatgpt.com/codex/tasks/task_e_6852824611f4832a98c216c63f17d37b