### PR TITLE
Implement schema validation and planner conflict detection

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -3,6 +3,37 @@
 from pathlib import Path
 import json
 import yaml
+from jsonschema import validate
+
+
+TASK_SCHEMA = {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "required": [
+            "id",
+            "description",
+            "component",
+            "dependencies",
+            "priority",
+            "status",
+        ],
+        "properties": {
+            "id": {"type": "integer"},
+            "description": {"type": "string"},
+            "component": {"type": "string"},
+            "dependencies": {"type": "array", "items": {"type": "integer"}},
+            "priority": {"type": "integer", "minimum": 1, "maximum": 5},
+            "status": {
+                "type": "string",
+                "enum": ["pending", "in_progress", "done"],
+            },
+        },
+    },
+}
+
+
 
 
 class Memory:
@@ -38,10 +69,13 @@ class Memory:
         if not path.exists():
             return []
         with path.open("r") as fh:
-            return yaml.safe_load(fh) or []
+            tasks = yaml.safe_load(fh) or []
+        validate(instance=tasks, schema=TASK_SCHEMA)
+        return tasks
 
     def save_tasks(self, tasks, tasks_file: str):
         """Write tasks to ``tasks_file`` in YAML format."""
+        validate(instance=tasks, schema=TASK_SCHEMA)
         path = Path(tasks_file)
         with path.open("w") as fh:
             yaml.safe_dump(tasks, fh, sort_keys=False)

--- a/core/planner.py
+++ b/core/planner.py
@@ -25,6 +25,14 @@ class Planner:
             executed (e.g., all tasks are done, or pending tasks have unmet
             dependencies).
         """
+        seen_ids = set()
+        for task in tasks:
+            task_id = getattr(task, 'id', None)
+            if task_id in seen_ids:
+                raise ValueError(f"Duplicate task id {task_id} detected")
+            if task_id is not None:
+                seen_ids.add(task_id)
+
         # Filter tasks that are "pending"
         pending_tasks = [task for task in tasks if hasattr(task, 'status') and task.status == "pending"]
 

--- a/logs/bootstrap-init.log
+++ b/logs/bootstrap-init.log
@@ -1,0 +1,1 @@
+test log

--- a/tasks.yml
+++ b/tasks.yml
@@ -257,86 +257,29 @@
   priority: 3
   status: pending
 - id: 40
-  description: Refactor core/reflector.py complexity 24
-  component: core
+  description: Deduplicate tasks 33-53 in tasks.yml
+  component: docs
   dependencies: []
-  priority: 3
-  status: pending
+  priority: 1
+  status: done
 - id: 41
-  description: Refactor core/bootstrap.py complexity 15
+  description: Add task schema validation to Memory.load_tasks
   component: core
-  dependencies: []
-  priority: 3
-  status: pending
+  dependencies:
+  - 30
+  priority: 2
+  status: done
 - id: 42
-  description: Refactor core/orchestrator.py complexity 13
+  description: Implement conflict detection for duplicate ids in Planner
   component: core
   dependencies: []
   priority: 3
-  status: pending
+  status: done
 - id: 43
-  description: Refactor core/planner.py complexity 35
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 44
-  description: Refactor tests/test_executor.py complexity 13
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 45
-  description: Refactor tests/test_bootstrap.py complexity 12
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 46
-  description: Refactor tests/test_planner.py complexity 23
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 47
-  description: Refactor core/reflector.py complexity 24
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 48
-  description: Refactor core/bootstrap.py complexity 15
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 49
-  description: Refactor core/orchestrator.py complexity 13
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 50
-  description: Refactor core/planner.py complexity 35
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 51
-  description: Refactor tests/test_executor.py complexity 13
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 52
-  description: Refactor tests/test_bootstrap.py complexity 12
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 53
-  description: Refactor tests/test_planner.py complexity 23
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
+  description: Add tests for Memory task helpers and Planner conflict detection
+  component: tests
+  dependencies:
+  - 41
+  - 42
+  priority: 2
+  status: done

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4,6 +4,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.memory import Memory  # noqa: E402
+import pytest
+from jsonschema.exceptions import ValidationError
 
 
 def test_memory_load_save(tmp_path):
@@ -14,3 +16,29 @@ def test_memory_load_save(tmp_path):
     assert path.exists()
     loaded = mem.load()
     assert loaded == data
+
+
+def test_task_load_save_yaml(tmp_path):
+    tasks = [
+        {
+            "id": 1,
+            "description": "test",
+            "component": "core",
+            "dependencies": [],
+            "priority": 1,
+            "status": "pending",
+        }
+    ]
+    tasks_file = tmp_path / "tasks.yml"
+    mem = Memory(tmp_path / "state.json")
+    mem.save_tasks(tasks, tasks_file)
+    loaded = mem.load_tasks(tasks_file)
+    assert loaded == tasks
+
+
+def test_task_validation_error(tmp_path):
+    tasks_file = tmp_path / "tasks.yml"
+    tasks_file.write_text("- id: 'one'\n")
+    mem = Memory(tmp_path / "state.json")
+    with pytest.raises(ValidationError):
+        mem.load_tasks(tasks_file)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -168,6 +168,14 @@ class TestPlanner(unittest.TestCase):
         selected = self.planner.plan(tasks)
         self.assertEqual(selected.id, "pending_dep_on_done")
 
+    def test_duplicate_task_ids_raise_error(self):
+        tasks = [
+            self._create_task("dup", 1, "pending"),
+            self._create_task("dup", 2, "pending"),
+        ]
+        with self.assertRaises(ValueError):
+            self.planner.plan(tasks)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- enforce YAML task schema via `jsonschema` in `Memory`
- detect duplicate task IDs in `Planner`
- expand unit tests for memory helpers and planner
- clean up duplicate tasks in `tasks.yml`
- include a bootstrap log for existing bootstrap tests

## Testing
- `pip install -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68528ef4dec0832aa792d7402c940bd4