### PR TITLE
Add async runner with tests

### DIFF
--- a/core/async_runner.py
+++ b/core/async_runner.py
@@ -1,0 +1,38 @@
+import asyncio
+import shlex
+from typing import Sequence, Union, Dict
+
+class AsyncRunner:
+    """Run shell commands asynchronously."""
+
+    async def run(self, command: Union[str, Sequence[str]]) -> Dict[str, Union[str, int]]:
+        """Execute ``command`` asynchronously and capture output.
+
+        Parameters
+        ----------
+        command:
+            The command to execute. Can be a string or sequence of arguments.
+
+        Returns
+        -------
+        dict
+            Dictionary with ``stdout``, ``stderr`` and ``exit_code``.
+        """
+        if isinstance(command, str):
+            args = shlex.split(command)
+        else:
+            args = list(command)
+
+        proc = await asyncio.create_subprocess_exec(
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+
+        stdout, stderr = await proc.communicate()
+
+        return {
+            "stdout": stdout.decode(),
+            "stderr": stderr.decode(),
+            "exit_code": proc.returncode,
+        }

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -1,0 +1,30 @@
+import asyncio
+import unittest
+
+from core.async_runner import AsyncRunner
+
+
+class TestAsyncRunner(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.runner = AsyncRunner()
+
+    async def test_run_echo(self):
+        result = await self.runner.run(["echo", "hello"])
+        self.assertEqual(result["stdout"].strip(), "hello")
+        self.assertEqual(result["stderr"], "")
+        self.assertEqual(result["exit_code"], 0)
+
+    async def test_run_failure(self):
+        result = await self.runner.run(["sh", "-c", "exit 1"])
+        self.assertNotEqual(result["exit_code"], 0)
+
+    async def test_concurrent_runs(self):
+        cmd = ["python3", "-c", "import time; time.sleep(0.5)"]
+        start = asyncio.get_event_loop().time()
+        await asyncio.gather(self.runner.run(cmd), self.runner.run(cmd))
+        duration = asyncio.get_event_loop().time() - start
+        self.assertLess(duration, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `AsyncRunner` for running shell commands asynchronously
- test async runner to ensure stdout, stderr, and exit codes are captured

## Testing
- `python -m pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a2deea6c832aae044f2dcc87e3e9