### PR TITLE
Fix test module imports

### DIFF
--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -1,3 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 import asyncio
 import unittest
 

--- a/tests/test_diff_utils.py
+++ b/tests/test_diff_utils.py
@@ -1,5 +1,9 @@
-import os
+import sys
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import os
 
 from core.diff_utils import generate_diff, generate_file_diff
 


### PR DESCRIPTION
## Summary
- ensure `core` imports work in `tests/test_async_runner.py`
- ensure `core` imports work in `tests/test_diff_utils.py`

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a7470698832a9fc05ca6d90e0c6d