### PR TITLE
Introduce Task dataclass and update workflow

### DIFF
--- a/core/planner.py
+++ b/core/planner.py
@@ -1,10 +1,14 @@
+from typing import List, Optional
+from .task import Task
+
+
 class Planner:
     """
     A class that plans the execution order of tasks.
     It prioritizes tasks based on their priority and dependencies.
     """
 
-    def plan(self, tasks: list) -> object | None:
+    def plan(self, tasks: List[Task]) -> Optional[Task]:
         """
         Determines the next task to execute based on priority and dependencies.
 
@@ -13,15 +17,10 @@ class Planner:
         have a status of "done".
 
         Args:
-            tasks: A list of task objects. Each task object is expected to have
-                   at least the following attributes:
-                   - id (any): A unique identifier for the task.
-                   - priority (int): The priority of the task (higher value means higher priority).
-                   - dependencies (list): A list of task IDs that this task depends on.
-                   - status (str): The current status of the task (e.g., "todo", "done").
+            tasks: A list of :class:`Task` objects ordered arbitrarily.
 
         Returns:
-            The next task object to execute, or None if no tasks can be
+            The next :class:`Task` object to execute, or ``None`` if no tasks can be
             executed (e.g., all tasks are done, or pending tasks have unmet
             dependencies).
         """

--- a/core/task.py
+++ b/core/task.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class Task:
+    """Simple representation of a unit of work."""
+
+    id: int
+    description: str
+    component: str
+    dependencies: List[int]
+    priority: int
+    status: str
+    command: Optional[str] = None

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -2,8 +2,8 @@ import os
 import unittest
 from pathlib import Path
 from unittest.mock import patch
-from types import SimpleNamespace
 from core.executor import Executor
+from core.task import Task
 
 class TestExecutor(unittest.TestCase):
 
@@ -12,13 +12,27 @@ class TestExecutor(unittest.TestCase):
 
     @patch('builtins.print')
     def test_execute_task_with_description(self, mock_print):
-        task = SimpleNamespace(id="t1", description="Task One Description")
+        task = Task(
+            id="t1",
+            description="Task One Description",
+            component="test",
+            dependencies=[],
+            priority=1,
+            status="pending",
+        )
         self.executor.execute(task)
         mock_print.assert_called_once_with("Executing task: Task One Description")
 
     @patch('builtins.print')
     def test_execute_task_with_id_no_description(self, mock_print):
-        task = SimpleNamespace(id="t2")
+        task = Task(
+            id="t2",
+            description="",
+            component="test",
+            dependencies=[],
+            priority=1,
+            status="pending",
+        )
         # Ensure description attribute is not present
         if hasattr(task, 'description'):
             delattr(task, 'description')
@@ -27,7 +41,14 @@ class TestExecutor(unittest.TestCase):
 
     @patch('builtins.print')
     def test_execute_task_no_description_no_id(self, mock_print):
-        task = SimpleNamespace()
+        task = Task(
+            id=0,
+            description="",
+            component="test",
+            dependencies=[],
+            priority=1,
+            status="pending",
+        )
         # Ensure description and id attributes are not present
         if hasattr(task, 'description'):
             delattr(task, 'description')
@@ -38,26 +59,45 @@ class TestExecutor(unittest.TestCase):
 
     @patch('builtins.print')
     def test_execute_task_as_dict_with_description(self, mock_print):
-        # The Executor currently expects an object with attributes, not a dict.
-        # This test is to confirm behavior if a dict-like object (still using dot access) is passed.
-        # If it were a true dict task['description'], the impl would need hasattr(task, 'get') or similar.
-        # For now, SimpleNamespace mimics attribute access.
-        task = SimpleNamespace(**{'id': 'd1', 'description': 'Dict Task Description'})
+        # The Executor expects an object with attributes. Using the Task
+        # dataclass mimics this interface and keeps the test focused on the
+        # print behavior rather than attribute lookups.
+        task = Task(
+            id="d1",
+            description="Dict Task Description",
+            component="test",
+            dependencies=[],
+            priority=1,
+            status="pending",
+        )
         self.executor.execute(task)
         mock_print.assert_called_once_with("Executing task: Dict Task Description")
 
     @patch('builtins.print')
     def test_execute_task_as_dict_with_id_no_description(self, mock_print):
-        task_dict = {'id': 'd2'}
-        task_obj = SimpleNamespace(**task_dict)
-        if hasattr(task_obj, 'description'): # Ensure no description
-             delattr(task_obj, 'description')
+        task_obj = Task(
+            id="d2",
+            description="",
+            component="test",
+            dependencies=[],
+            priority=1,
+            status="pending",
+        )
+        if hasattr(task_obj, 'description'):
+            delattr(task_obj, 'description')
         self.executor.execute(task_obj)
         mock_print.assert_called_once_with("Executing task ID: d2 (No description found)")
 
     @patch('builtins.print')
     def test_execute_task_object_with_other_attributes(self, mock_print):
-        task = SimpleNamespace(id="t_other", description="Other attributes test", priority=10, status="pending")
+        task = Task(
+            id="t_other",
+            description="Other attributes test",
+            component="test",
+            dependencies=[],
+            priority=10,
+            status="pending",
+        )
         self.executor.execute(task)
         mock_print.assert_called_once_with("Executing task: Other attributes test")
 
@@ -68,7 +108,15 @@ class TestExecutor(unittest.TestCase):
             cwd = os.getcwd()
             os.chdir(tmpdir)
             try:
-                task = SimpleNamespace(id="cmd", description="Run echo", command="echo hello")
+                task = Task(
+                    id="cmd",
+                    description="Run echo",
+                    component="test",
+                    dependencies=[],
+                    priority=1,
+                    status="pending",
+                    command="echo hello",
+                )
                 self.executor.execute(task)
             finally:
                 os.chdir(cwd)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4,6 +4,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.memory import Memory  # noqa: E402
+from core.task import Task
 import pytest
 from jsonschema.exceptions import ValidationError
 
@@ -20,14 +21,14 @@ def test_memory_load_save(tmp_path):
 
 def test_task_load_save_yaml(tmp_path):
     tasks = [
-        {
-            "id": 1,
-            "description": "test",
-            "component": "core",
-            "dependencies": [],
-            "priority": 1,
-            "status": "pending",
-        }
+        Task(
+            id=1,
+            description="test",
+            component="core",
+            dependencies=[],
+            priority=1,
+            status="pending",
+        )
     ]
     tasks_file = tmp_path / "tasks.yml"
     mem = Memory(tmp_path / "state.json")

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,6 +1,6 @@
 import unittest
-from types import SimpleNamespace
 from core.planner import Planner
+from core.task import Task
 
 class TestPlanner(unittest.TestCase):
 
@@ -11,7 +11,7 @@ class TestPlanner(unittest.TestCase):
         """Helper to create task-like objects."""
         if dependencies is None:
             dependencies = []
-        return SimpleNamespace(id=id, priority=priority, status=status, dependencies=dependencies, description=description)
+        return Task(id=id, priority=priority, status=status, dependencies=dependencies, description=description, component="test")
 
     def test_empty_tasks_list(self):
         self.assertIsNone(self.planner.plan([]), "Should return None for empty task list")
@@ -123,8 +123,8 @@ class TestPlanner(unittest.TestCase):
         self.assertIsNone(self.planner.plan(tasks_blocked), "Should return None if all pending tasks are blocked by missing deps")
 
     def test_task_with_no_dependencies_attribute(self):
-        task_no_deps_attr = SimpleNamespace(id="t_no_dep_attr", priority=10, status="pending", description="Test")
-        if hasattr(task_no_deps_attr, 'dependencies'): # Ensure it's not there
+        task_no_deps_attr = self._create_task("t_no_dep_attr", 10, "pending")
+        if hasattr(task_no_deps_attr, 'dependencies'):
             delattr(task_no_deps_attr, 'dependencies')
 
         selected_task = self.planner.plan([task_no_deps_attr])
@@ -137,7 +137,9 @@ class TestPlanner(unittest.TestCase):
         self.assertEqual(selected_task.id, "t_empty_deps", "Should select task with empty dependencies list")
 
     def test_task_object_without_priority_attribute_defaults_to_zero(self):
-        task_no_priority = SimpleNamespace(id="t_no_prio", status="pending", dependencies=[], description="Test")
+        task_no_priority = self._create_task("t_no_prio", 0, "pending", [])
+        if hasattr(task_no_priority, 'priority'):
+            delattr(task_no_priority, 'priority')
         task_with_priority_one = self._create_task("t_with_prio", 1, "pending")
 
         # Test order 1: no_priority first in list


### PR DESCRIPTION
## Summary
- add `Task` dataclass in `core/task.py`
- support `Task` objects in `Memory`
- update `Planner` and `Orchestrator` to work with `Task`
- adapt tests to use `Task`

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852af8d7c44832a8347968a7653d877