### PR TITLE
Add shared fixture for sys.path in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+@pytest.fixture(scope="session", autouse=True)
+def add_project_root_to_sys_path():
+    yield
+    if str(ROOT) in sys.path:
+        sys.path.remove(str(ROOT))

--- a/tests/test_async_runner.py
+++ b/tests/test_async_runner.py
@@ -1,8 +1,3 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
 import asyncio
 import unittest
 

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -3,7 +3,6 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT))
 
 from core.bootstrap import load_schema_and_tasks  # noqa: E402
 from core.memory import TASK_SCHEMA

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,5 @@
 import subprocess
 import sys
-from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 
 def test_cli_runs(tmp_path):

--- a/tests/test_diff_utils.py
+++ b/tests/test_diff_utils.py
@@ -1,9 +1,5 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
 import os
+
 
 from core.diff_utils import generate_diff, generate_file_diff
 

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,8 +1,3 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-
 from core.memory import Memory  # noqa: E402
 import pytest
 from jsonschema.exceptions import ValidationError

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -1,8 +1,3 @@
-import sys
-from pathlib import Path
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
-
 import yaml  # noqa: E402
 from core.reflector import Reflector  # noqa: E402
 

--- a/tests/test_self_auditor.py
+++ b/tests/test_self_auditor.py
@@ -1,8 +1,4 @@
-import sys
-from pathlib import Path
 import os
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from core.self_auditor import SelfAuditor  # noqa: E402
 


### PR DESCRIPTION
## Summary
- add autouse fixture in `conftest.py` to prepend project root to `sys.path`
- remove per-file `sys.path.insert` calls from test modules

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b1831fbc832ab245182ead04ad92