### PR TITLE
Add Docker support for broker

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -259,6 +259,16 @@ retrieve an individual task by ID. The database path defaults to
 ``tasks.db`` but can be overridden via the ``DB_PATH`` environment
 variable.
 
+To run the broker inside a container build the image and publish port
+``8000``:
+
+```bash
+docker build -f broker/Dockerfile -t broker .
+docker run -p 8000:8000 broker
+```
+
+The container launches ``uvicorn broker.main:app``.
+
 ```python
 from fastapi import FastAPI
 import sqlite3

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY broker ./broker
+EXPOSE 8000
+ENTRYPOINT ["uvicorn", "broker.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/tests/test_broker_api.py
+++ b/tests/test_broker_api.py
@@ -1,6 +1,11 @@
 import os
 from importlib import reload
 from pathlib import Path
+import shutil
+import subprocess
+import time
+import requests
+import pytest
 
 from fastapi.testclient import TestClient
 
@@ -27,3 +32,50 @@ def test_create_and_get_task(tmp_path):
     resp = client.get(f"/tasks/{task_id}")
     assert resp.status_code == 200
     assert resp.json()["id"] == task_id
+
+
+@pytest.mark.skipif(shutil.which("docker") is None, reason="Docker not installed")
+def test_broker_container(tmp_path):
+    root = Path(__file__).resolve().parents[1]
+    image = "broker-test"
+    subprocess.run([
+        "docker",
+        "build",
+        "-t",
+        image,
+        "-f",
+        str(root / "broker" / "Dockerfile"),
+        str(root),
+    ], check=True)
+
+    proc = subprocess.Popen(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-p",
+            "8001:8000",
+            "-e",
+            f"DB_PATH={tmp_path/'api.db'}",
+            image,
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+
+    try:
+        for _ in range(20):
+            try:
+                r = requests.get("http://localhost:8001/tasks", timeout=1)
+                if r.status_code == 200:
+                    break
+            except requests.RequestException:
+                time.sleep(0.5)
+
+        resp = requests.post("http://localhost:8001/tasks", json={"description": "demo"})
+        assert resp.status_code == 200
+        resp = requests.get("http://localhost:8001/tasks")
+        assert any(t["description"] == "demo" for t in resp.json())
+    finally:
+        proc.terminate()
+        proc.wait(timeout=10)


### PR DESCRIPTION
## Summary
- containerize the FastAPI broker
- document how to build and run the broker container
- verify the container in a new integration test

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b169a334832aae1c52d8d7e0277d