### PR TITLE
Integrate wily metrics into auditor

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,8 +157,9 @@ refactor suggestion.
 
 ```python
 class SelfAuditor:
-    def __init__(self, threshold: int = 15):
+    def __init__(self, threshold: int = 15, use_wily: bool = False):
         self.threshold = threshold
+        self.use_wily = use_wily
 
     def analyze(self, paths):
         """Return a mapping of file paths to radon metrics."""
@@ -166,6 +167,11 @@ class SelfAuditor:
     def audit(self, tasks):
         """Return new task entries when complexity exceeds ``self.threshold``."""
 ```
+
+When ``use_wily`` is enabled the auditor runs ``wily build`` to update the
+history cache and reads metrics from the previous revision. The difference in
+complexity influences task priority—files getting worse are prioritised while
+improvements lower the urgency.
 
 After each execution cycle the `Orchestrator` calls `SelfAuditor.audit()` with
 the current task list. Any returned entries are appended through the `Planner`,

--- a/core/self_auditor.py
+++ b/core/self_auditor.py
@@ -14,9 +14,15 @@ from radon.metrics import mi_visit, mi_rank
 class SelfAuditor:
     """Evaluate metrics and produce refactor tasks when thresholds are exceeded."""
 
-    def __init__(self, complexity_threshold: int = 15, maintainability_threshold: str = "B") -> None:
+    def __init__(
+        self,
+        complexity_threshold: int = 15,
+        maintainability_threshold: str = "B",
+        use_wily: bool = False,
+    ) -> None:
         self.complexity_threshold = complexity_threshold
         self.maintainability_threshold = maintainability_threshold
+        self.use_wily = use_wily
         self.logger = logging.getLogger(__name__)
 
     # ------------------------------------------------------------------
@@ -24,6 +30,25 @@ class SelfAuditor:
         """Return metrics for ``paths`` which should be Python files."""
 
         results: Dict[str, Dict] = {}
+        wily_state = None
+        wily_config = None
+        if self.use_wily:
+            try:
+                from wily.config import DEFAULT_CONFIG
+                from wily.commands.build import build
+                from wily.archivers import resolve_archiver
+                from wily.operators import resolve_operators
+                from wily.state import State
+
+                wily_config = DEFAULT_CONFIG
+                wily_config.path = "."
+                archiver = resolve_archiver(wily_config.archiver)
+                operators = resolve_operators(wily_config.operators)
+                build(wily_config, archiver, operators)
+                wily_state = State(wily_config)
+            except Exception as exc:  # pragma: no cover - wily optional
+                self.logger.warning("Wily processing failed: %s", exc)
+
         for path in paths:
             if not path.exists() or path.suffix != ".py":
                 continue
@@ -37,6 +62,11 @@ class SelfAuditor:
                 continue
 
             file_metrics = self._analyze_file(str(path), text)
+
+            if self.use_wily and wily_state and wily_config:
+                history = self._wily_history(wily_state, wily_config, path)
+                if history:
+                    file_metrics["history"] = history
             results[str(path)] = file_metrics
 
         return results
@@ -94,6 +124,46 @@ class SelfAuditor:
         return order.get(current, 5) > order.get(threshold, 2)
 
     # ------------------------------------------------------------------
+    def _wily_history(self, state, config, path: Path) -> Dict:
+        """Return historical metrics for ``path`` using wily."""
+        try:
+            rel = str(path.relative_to(config.path))
+        except ValueError:
+            rel = str(path)
+
+        revisions = state.index[state.default_archiver].revisions
+        if len(revisions) < 2:
+            return {}
+
+        current_rev = revisions[0]
+        previous_rev = revisions[1]
+
+        try:
+            current_complexity = current_rev.get(
+                config, state.default_archiver, "cyclomatic", rel, "complexity"
+            )
+            prev_complexity = previous_rev.get(
+                config, state.default_archiver, "cyclomatic", rel, "complexity"
+            )
+            current_mi = current_rev.get(
+                config, state.default_archiver, "maintainability", rel, "mi"
+            )
+            prev_mi = previous_rev.get(
+                config, state.default_archiver, "maintainability", rel, "mi"
+            )
+        except Exception:
+            return {}
+
+        return {
+            "previous_complexity": prev_complexity,
+            "current_complexity": current_complexity,
+            "delta_complexity": current_complexity - prev_complexity,
+            "previous_mi": prev_mi,
+            "current_mi": current_mi,
+            "delta_mi": current_mi - prev_mi,
+        }
+
+    # ------------------------------------------------------------------
     def _get_existing_refactor_files(self, existing_tasks: List[Dict]) -> set:
         files = set()
         for task in existing_tasks:
@@ -127,6 +197,14 @@ class SelfAuditor:
 
         if violations > 5:
             priority += 1
+
+        history = metrics.get("history", {})
+        delta = history.get("delta_complexity")
+        if isinstance(delta, (int, float)):
+            if delta > 0:
+                priority += 1
+            elif delta < 0:
+                priority -= 1
 
         return max(1, min(5, priority))
 
@@ -174,6 +252,9 @@ class SelfAuditor:
                     "generated_by": "SelfAuditor",
                 },
             }
+
+            if "history" in file_metrics:
+                task["metadata"].update(file_metrics["history"])
 
             new_tasks.append(task)
             next_id += 1

--- a/tasks.yml
+++ b/tasks.yml
@@ -92,7 +92,7 @@
   dependencies:
   - 9
   priority: 3
-  status: pending
+  status: done
 - id: 11
   description: Orchestrator generates refactor tasks when SelfAuditor thresholds exceeded
   component: orchestrator
@@ -168,7 +168,6 @@
   dependencies: []
   priority: 2
   status: done
-# flake8 and pre-commit settings are in `.pre-commit-config.yml` and `setup.cfg`
 - id: 26
   description: Configure flake8 and pre-commit for code style enforcement
   component: deps
@@ -360,3 +359,37 @@
         task_ids:
         - 37
         - 46
+- id: 52
+  description: Clean up 5 duplicate tasks
+  component: maintenance
+  dependencies: []
+  priority: 2
+  status: pending
+  metadata:
+    type: technical_debt
+    generated_by: Reflector
+    decision_type: task_cleanup
+    details:
+      type: task_cleanup
+      reason: Duplicate tasks detected
+      duplicates:
+      - description: Refactor tests/test_bootstrap.py complexity 12
+        task_ids:
+        - 38
+        - 44
+      - description: Refactor tests/test_executor.py complexity 13
+        task_ids:
+        - 37
+        - 46
+      - description: Refactor core/bootstrap.py complexity 15
+        task_ids:
+        - 34
+        - 47
+      - description: Refactor core/orchestrator.py complexity 13
+        task_ids:
+        - 35
+        - 49
+      - description: Refactor core/reflector.py complexity 24
+        task_ids:
+        - 33
+        - 50

--- a/tests/test_self_auditor.py
+++ b/tests/test_self_auditor.py
@@ -33,3 +33,38 @@ def test_self_auditor_analyze(tmp_path):
     key = str(target)
     assert key in metrics
     assert metrics[key]["maintainability"]["mi"] > 0
+
+
+def test_self_auditor_wily_history(tmp_path):
+    """Ensure wily metrics are incorporated when enabled."""
+    import subprocess
+
+    repo = tmp_path
+    subprocess.run(["git", "init"], cwd=repo)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=repo)
+    subprocess.run(["git", "config", "user.name", "Tester"], cwd=repo)
+
+    sample = repo / "sample.py"
+    sample.write_text("def foo(x):\n    return x\n")
+    subprocess.run(["git", "add", "sample.py"], cwd=repo)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=repo)
+
+    sample.write_text(
+        "def foo(x):\n    if x > 1:\n        return 1\n    else:\n        return 0\n"
+    )
+    subprocess.run(["git", "add", "sample.py"], cwd=repo)
+    subprocess.run(["git", "commit", "-m", "update"], cwd=repo)
+
+    auditor = SelfAuditor(complexity_threshold=1, use_wily=True)
+
+    cwd = os.getcwd()
+    os.chdir(repo)
+    try:
+        tasks = auditor.audit([])
+    finally:
+        os.chdir(cwd)
+
+    assert tasks
+    meta = tasks[0]["metadata"]
+    assert "delta_complexity" in meta
+    assert meta["delta_complexity"] != 0


### PR DESCRIPTION
## Summary
- extend `SelfAuditor` with optional wily history processing
- modify refactor task priority based on complexity trends
- document wily influence in `ARCHITECTURE.md`
- mark wily integration task as complete
- test historical metric handling

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b17dc130832ab072feb60f8c43c4