### PR TITLE
feat: run executor without shell

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import shlex
 from datetime import datetime
 from pathlib import Path
 
@@ -33,9 +34,8 @@ class Executor:
         if not command:
             return
 
-        result = subprocess.run(
-            command, shell=True, capture_output=True, text=True
-        )
+        args = shlex.split(command)
+        result = subprocess.run(args, capture_output=True, text=True)
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         log_dir = Path("logs")
         log_dir.mkdir(exist_ok=True)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -115,7 +115,7 @@ class TestExecutor(unittest.TestCase):
                     dependencies=[],
                     priority=1,
                     status="pending",
-                    command="echo hello",
+                    command="echo 'hello there'",
                 )
                 self.executor.execute(task)
             finally:
@@ -123,7 +123,7 @@ class TestExecutor(unittest.TestCase):
 
             logs = list(Path(tmpdir).joinpath("logs").glob("task-cmd-*.log"))
             assert logs, "Log file not created"
-            assert logs[0].read_text().strip() == "hello"
+            assert logs[0].read_text().strip() == "hello there"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- avoid use of shell=True inside Executor
- split command with shlex
- adapt executor test to match quoting

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b40baa14832abcfb52e0f3ac9225