### PR TITLE
Add pre-commit and flake8 workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,W503

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Install lint tools
+        run: |
+          pip install pylint==3.3.7 flake8==7.2.0
+      - name: Run flake8
+        run: flake8 core tests
+      - name: Run pylint
+        run: |
+          pylint --exit-zero core tests
+      - name: Run tests
+        run: |
+          pytest --maxfail=1 --disable-warnings -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pycqa/pylint
+    rev: v3.3.7
+    hooks:
+      - id: pylint
+        args: ["--exit-zero"]

--- a/README.md
+++ b/README.md
@@ -223,7 +223,13 @@ Your mission is to parse this document, form your plan, and then execute the ins
     ```
     * All tests must pass.
 
-3.  **Commit Genesis State**
+3.  **Set up Pre-commit Hooks**
+    ```bash
+    pre-commit install
+    ```
+    * Hooks run `black`, `flake8`, and `pylint` automatically.
+
+4.  **Commit Genesis State**
     ```bash
     cat <<EOF > .gitignore
     __pycache__/

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+"""Core package containing orchestrator components."""

--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -1,3 +1,5 @@
+"""Bootstrap the AI-SWA environment and validate tasks."""
+
 import json
 import logging
 import sys

--- a/core/cli.py
+++ b/core/cli.py
@@ -1,3 +1,5 @@
+"""Command line interface for AI-SWA orchestration."""
+
 import argparse
 from pathlib import Path
 

--- a/core/executor.py
+++ b/core/executor.py
@@ -1,3 +1,6 @@
+"""Execution component running discrete tasks."""
+
+
 class Executor:
     """Execute planned tasks."""
 

--- a/core/memory.py
+++ b/core/memory.py
@@ -1,3 +1,5 @@
+"""Persistent storage utility for tasks and metadata."""
+
 from pathlib import Path
 import json
 

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -1,3 +1,6 @@
+"""High-level coordinator for planner, executor and auditor."""
+
+
 class Orchestrator:
     """Coordinate planner, executor, auditor and persistence."""
 

--- a/core/planner.py
+++ b/core/planner.py
@@ -1,3 +1,6 @@
+"""Simple decision maker selecting the next task."""
+
+
 class Planner:
     """Determine the next action based on available tasks."""
 

--- a/core/reflector.py
+++ b/core/reflector.py
@@ -1,3 +1,5 @@
+"""Provide reflection utilities for self-improvement loops."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -49,19 +51,21 @@ class Reflector:
         next_id = self._next_id(tasks)
         for path, score in metrics.items():
             if score > self.threshold:
-                new_tasks.append({
-                    "id": next_id,
-                    "description": f"Refactor {path} complexity {score}",
-                    "component": "core",
-                    "dependencies": [],
-                    "priority": 3,
-                    "status": "pending",
-                })
+                new_tasks.append(
+                    {
+                        "id": next_id,
+                        "description": f"Refactor {path} complexity {score}",
+                        "component": "core",
+                        "dependencies": [],
+                        "priority": 3,
+                        "status": "pending",
+                    }
+                )
                 next_id += 1
         return new_tasks
 
     def run_cycle(self):
-        files = self.paths or list(Path('.').rglob('*.py'))
+        files = self.paths or list(Path(".").rglob("*.py"))
         metrics = self._analyze(files)
         tasks = self._load_tasks()
         new_tasks = self._decide(metrics, tasks)

--- a/core/self_auditor.py
+++ b/core/self_auditor.py
@@ -1,3 +1,6 @@
+"""Utility to inspect executed tasks and gather metrics."""
+
+
 class SelfAuditor:
     """Inspect results of executed tasks."""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,6 @@ PyYAML==6.0.1
 pytest==7.4.0
 jsonschema==4.21.0
 radon==5.1.0
+pylint==3.3.7
+flake8==7.2.0
+pre-commit==3.7.0

--- a/tasks.yml
+++ b/tasks.yml
@@ -154,3 +154,39 @@
   dependencies: []
   priority: 3
   status: done
+- id: 24
+  description: Add missing module docstrings across core modules
+  component: docs
+  dependencies: []
+  priority: 2
+  status: done
+- id: 25
+  description: Set up GitHub Actions workflow to run pytest and pylint
+  component: ci
+  dependencies: []
+  priority: 2
+  status: done
+- id: 26
+  description: Configure flake8 and pre-commit for code style enforcement
+  component: deps
+  dependencies: []
+  priority: 3
+  status: done
+- id: 27
+  description: Add flake8 configuration and fix style errors
+  component: code
+  dependencies: [26]
+  priority: 2
+  status: done
+- id: 28
+  description: Add pre-commit configuration running flake8 and pylint
+  component: ci
+  dependencies: [27]
+  priority: 2
+  status: done
+- id: 29
+  description: Document flake8 and pre-commit usage in README
+  component: docs
+  dependencies: [28]
+  priority: 3
+  status: done

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -48,7 +48,7 @@ def test_schema_error(tmp_path):
 def test_load_schema_and_tasks(tmp_path):
     content = (
         "# jsonschema:\n"
-        "# {\"type\": \"array\"}\n"
+        '# {"type": "array"}\n'
         "- id: 1\n"
         "  description: test\n"
         "  component: core\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import subprocess
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -18,7 +18,8 @@ def test_reflector_creates_task(tmp_path):
         "  status: pending\n"
     )
     code_file = tmp_path / "complex.py"
-    code_file.write_text("""\
+    code_file.write_text(
+        """\
 def func(x):
     if x > 0:
         if x > 1:
@@ -27,7 +28,8 @@ def func(x):
             return 2
     else:
         return 3
-""")
+"""
+    )
     refl = Reflector(tasks_path=tasks_file, threshold=1, paths=[code_file])
     new_tasks = refl.run_cycle()
     assert new_tasks


### PR DESCRIPTION
## Summary
- mark tasks 27-29 in progress then done
- add `.flake8` config and pre-commit hooks
- install flake8 and pre-commit in requirements
- run black on repository via pre-commit
- extend CI workflow with flake8
- document pre-commit usage in README

## Testing
- `pre-commit run --all-files`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_685279285440832a9bd923d43b37b176