### PR TITLE
Implement result reporting from worker to broker

### DIFF
--- a/tests/test_worker_broker_flow.py
+++ b/tests/test_worker_broker_flow.py
@@ -1,0 +1,61 @@
+import os
+import sqlite3
+from importlib import reload
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+import broker.main as broker_module
+import worker.main as worker_module
+
+
+def setup_broker(tmp_path):
+    os.environ["DB_PATH"] = str(tmp_path / "api.db")
+    broker = reload(broker_module)
+    return TestClient(broker.app)
+
+
+def run_worker(client, monkeypatch):
+    os.environ["BROKER_URL"] = str(client.base_url)
+    mod = reload(worker_module)
+
+    def _get(url, *args, **kwargs):
+        return client.get(url.replace(str(client.base_url), ""))
+
+    def _post(url, *args, **kwargs):
+        return client.post(url.replace(str(client.base_url), ""), json=kwargs.get("json"))
+
+    monkeypatch.setattr(mod, "requests", SimpleNamespace(get=_get, post=_post))
+    mod.main()
+
+
+def fetch_result(db_path, task_id):
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT stdout, stderr, exit_code FROM task_results WHERE task_id=?",
+        (task_id,),
+    ).fetchone()
+    conn.close()
+    return row
+
+
+def test_worker_success_result(tmp_path, monkeypatch):
+    client = setup_broker(tmp_path)
+    resp = client.post("/tasks", json={"description": "demo", "command": "echo hi"})
+    task_id = resp.json()["id"]
+    run_worker(client, monkeypatch)
+    stdout, stderr, code = fetch_result(str(tmp_path / "api.db"), task_id)
+    assert stdout.strip() == "hi"
+    assert stderr == ""
+    assert code == 0
+
+
+def test_worker_failure_result(tmp_path, monkeypatch):
+    client = setup_broker(tmp_path)
+    cmd = "sh -c 'echo fail >&2; exit 1'"
+    resp = client.post("/tasks", json={"description": "fail", "command": cmd})
+    task_id = resp.json()["id"]
+    run_worker(client, monkeypatch)
+    stdout, stderr, code = fetch_result(str(tmp_path / "api.db"), task_id)
+    assert code != 0
+    assert "fail" in stderr

--- a/worker/main.py
+++ b/worker/main.py
@@ -16,7 +16,17 @@ def main():
     for task in tasks:
         command = task.get("command")
         if command:
-            subprocess.run(command, shell=True, check=False)
+            result = subprocess.run(
+                command, shell=True, check=False, capture_output=True, text=True
+            )
+            requests.post(
+                f"{BROKER_URL}/tasks/{task['id']}/result",
+                json={
+                    "stdout": result.stdout,
+                    "stderr": result.stderr,
+                    "exit_code": result.returncode,
+                },
+            ).raise_for_status()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend the broker API to store commands and task results
- update the worker to POST command output back to the broker
- cover the workflow with integration tests

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852ba432f3c832a9b5ea0c1ddc1f3d1