### PR TITLE
Add research brief and epic tasks

### DIFF
--- a/docs/research/RB-002_Strategic_Roadmap_Extension.md
+++ b/docs/research/RB-002_Strategic_Roadmap_Extension.md
@@ -1,0 +1,15 @@
+# Research Brief RB-002: Strategic Roadmap Extension
+
+This brief summarizes advanced research directions for AI-SWA.
+
+## Proposed Research Tasks
+
+1. **Vision Engine Prioritization** - Investigate heuristic and reinforcement learning approaches for ranking future epics.
+2. **Cross-Language Architecture** - Explore integrating Rust for performance tasks and Node.js for I/O bound services via a microservice design.
+3. **Metrics & Observability Blueprint** - Define an OpenTelemetry + Prometheus + Grafana stack to feed data back into the Reflector.
+4. **Plugin Ecosystem Governance** - Design an automated CI/CD pipeline for plugin security, compliance and signing.
+5. **Ethical Sentinel Policy Catalog** - Map industry AI ethics frameworks to concrete policies enforced by the Sentinel.
+6. **Self-Improvement Loop Optimization** - Prototype reinforcement learning and evolutionary strategies for the Reflector's learning loop.
+7. **Community & Ecosystem Mapping** - Survey open-source agent frameworks and commercial platforms to position AI-SWA as a meta-platform.
+
+These tasks extend the vision outlined in the repository manifesto and roadmap. They provide the foundation for a new research epic in `tasks.yml`.

--- a/tasks.yml
+++ b/tasks.yml
@@ -393,3 +393,58 @@
         task_ids:
         - 33
         - 50
+- id: 53
+  description: Document strategic research roadmap (RB-002)
+  component: docs
+  dependencies: []
+  priority: 2
+  status: pending
+- id: 54
+  description: Outline Vision Engine prioritization research
+  component: research
+  dependencies:
+  - 53
+  priority: 3
+  status: pending
+- id: 55
+  description: Outline cross-language architecture research
+  component: research
+  dependencies:
+  - 53
+  priority: 3
+  status: pending
+- id: 56
+  description: Outline metrics and observability research
+  component: research
+  dependencies:
+  - 53
+  priority: 3
+  status: pending
+- id: 57
+  description: Outline plugin governance research
+  component: research
+  dependencies:
+  - 53
+  priority: 3
+  status: pending
+- id: 58
+  description: Outline ethical sentinel policy research
+  component: research
+  dependencies:
+  - 53
+  priority: 3
+  status: pending
+- id: 59
+  description: Outline self-improvement optimization research
+  component: research
+  dependencies:
+  - 53
+  priority: 3
+  status: pending
+- id: 60
+  description: Outline community and ecosystem mapping research
+  component: research
+  dependencies:
+  - 53
+  priority: 3
+  status: pending


### PR DESCRIPTION
## Summary
- create docs/research directory with RB-002 Strategic Roadmap brief
- add new research epic tasks covering prioritization, cross-language design, metrics, governance, ethics, self-improvement, and ecosystem mapping

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b726c36c832a8fa8482853cf16b2