### PR TITLE
Add core component instantiation tests

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -157,15 +157,21 @@ refactor suggestion.
 
 ```python
 class SelfAuditor:
-    def __init__(self, threshold: int = 15, use_wily: bool = False):
-        self.threshold = threshold
+    def __init__(
+        self,
+        complexity_threshold: int = 15,
+        maintainability_threshold: str = "B",
+        use_wily: bool = False,
+    ):
+        self.complexity_threshold = complexity_threshold
+        self.maintainability_threshold = maintainability_threshold
         self.use_wily = use_wily
 
     def analyze(self, paths):
         """Return a mapping of file paths to radon metrics."""
 
     def audit(self, tasks):
-        """Return new task entries when complexity exceeds ``self.threshold``."""
+        """Return new task entries when metrics exceed configured thresholds."""
 ```
 
 When ``use_wily`` is enabled the auditor runs ``wily build`` to update the

--- a/tests/test_core_stubs.py
+++ b/tests/test_core_stubs.py
@@ -1,0 +1,32 @@
+import os
+import types
+from core.planner import Planner
+from core.executor import Executor
+from core.self_auditor import SelfAuditor
+
+def test_planner_instantiation_and_plan():
+    planner = Planner()
+    assert planner.plan([]) is None
+
+def test_executor_instantiation_and_execute(tmp_path):
+    executor = Executor()
+    task = types.SimpleNamespace(description="do nothing")
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        executor.execute(task)
+    finally:
+        os.chdir(cwd)
+
+def test_self_auditor_instantiation_and_methods(tmp_path):
+    sample = tmp_path / "example.py"
+    sample.write_text("def foo():\n    return 1\n")
+    auditor = SelfAuditor()
+    cwd = os.getcwd()
+    os.chdir(tmp_path)
+    try:
+        assert auditor.analyze([sample])
+        result = auditor.audit([])
+    finally:
+        os.chdir(cwd)
+    assert isinstance(result, list)


### PR DESCRIPTION
## Summary
- document updated SelfAuditor init signature in ARCHITECTURE.md
- add lightweight tests checking Planner, Executor and SelfAuditor can be instantiated and methods called

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c25409f0832aa495cfdf61500f7f