### PR TITLE
Add CLI help and error tests

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 from pathlib import Path
+import sys
 
 from .orchestrator import Orchestrator
 from .memory import Memory
@@ -27,13 +28,20 @@ def main(argv=None):
     args = parser.parse_args(argv)
 
     memory = Memory(Path(args.memory))
+    try:
+        memory.save(memory.load())
+    except Exception as exc:  # pragma: no cover - unexpected I/O errors
+        print(f"Error accessing memory: {exc}", file=sys.stderr)
+        return 1
+
     planner = Planner()
     executor = Executor()
     reflector = Reflector()
     orchestrator = Orchestrator(planner, executor, reflector, memory)
     print("Orchestrator running")
     orchestrator.run()
+    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover
-    main()
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,7 @@
 import subprocess
 import sys
+import os
+from pathlib import Path
 
 
 def test_cli_runs(tmp_path):
@@ -10,11 +12,52 @@ def test_cli_runs(tmp_path):
         "--memory",
         str(tmp_path / "state.json"),
     ]
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     result = subprocess.run(
         cmd,
+        cwd=tmp_path,
         capture_output=True,
         text=True,
+        env=env,
         check=False,
     )
     assert result.returncode == 0
     assert "Orchestrator running" in result.stdout
+
+
+def test_cli_help(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    result = subprocess.run(
+        [sys.executable, "-m", "core.cli", "--help"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()
+
+
+def test_cli_unwritable_memory(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "core.cli",
+            "--memory",
+            str(memory_dir),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- check memory path accessibility in CLI
- test CLI help output
- test CLI failure when memory path unwritable

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c259c574832aa82b080b209b4134