### PR TITLE
Add code quality research and SelfAuditor planning

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -77,10 +77,21 @@ class Executor:
 ```
 
 ### SelfAuditor
+Inspects code quality metrics and generates refactor tasks when complexity
+is high. Metrics are gathered using **radon** and optionally tracked over time
+with **wily**. The auditor does not change code directly; instead it returns a
+list of new tasks for the `Planner` to merge into `tasks.yml`.
+
 ```python
 class SelfAuditor:
-    def audit(self):
-        pass
+    def __init__(self, threshold: int = 15):
+        self.threshold = threshold
+
+    def analyze(self, paths):
+        """Return radon metrics for the given module paths."""
+
+    def audit(self, tasks):
+        """Inspect code and return new task dictionaries when limits are exceeded."""
 ```
 
 ## Bootstrapping Flow
@@ -106,6 +117,9 @@ flowchart TD
 - **PyYAML==6.0.1** - Safe YAML parsing
 - **pytest==7.4.0** - Test execution
 - **jsonschema==4.21.0** - Validate task schema
+- **radon==5.1.0** - Compute code complexity metrics
+- **wily==1.25.0** - Track complexity over Git history
+- **pylint==3.3.7** - Linting and style checks
 
 ## Persistence Strategy
 State such as tasks and logs are stored on disk. Tasks are kept in `tasks.yml` and

--- a/research/RB-001_Code_Quality_Analysis.md
+++ b/research/RB-001_Code_Quality_Analysis.md
@@ -1,0 +1,29 @@
+# Research Brief RB-001: Code Quality Analysis for SelfAuditor
+
+## Library Comparison
+
+### Radon 5.1.0
+- Provides command line and API access to cyclomatic complexity (CC), raw metrics, maintainability index (MI) and Halstead complexity.
+- Lightweight with minimal dependencies (`mando`, `colorama`, `six`).
+- Suitable for on-demand analysis of individual modules.
+
+### Wily 1.25.0
+- Builds on Radon and Git history to track complexity and maintainability over time.
+- Stores historical metrics in a local database; supports plotting and comparison between revisions.
+- Higher overhead but useful for trend-based auditing.
+
+### Pylint 3.3.7
+- Full static analysis linter producing code style warnings and an overall score.
+- Detects dead code, unused variables and potential errors beyond complexity metrics.
+- Can be slower but offers comprehensive quality checks.
+
+## Proposed Heuristic
+- Run Radon on modified modules after each orchestration cycle.
+- If any function has CC > **15** or module MI < **60**, flag it for refactoring.
+- Optionally use Wily for historical trends; if complexity continually rises over three revisions, escalate priority.
+
+## Implementation Strategy
+- The SelfAuditor should **not** modify code directly.
+- When thresholds are exceeded, it appends a new task entry to `tasks.yml` describing the recommended refactor.
+- Planner then incorporates these tasks into future iterations.
+

--- a/tasks.yml
+++ b/tasks.yml
@@ -64,3 +64,21 @@
   dependencies: [2]
   priority: 4
   status: done
+- id: 9
+  description: Implement SelfAuditor skeleton using radon metrics
+  component: auditor
+  dependencies: []
+  priority: 2
+  status: pending
+- id: 10
+  description: Integrate wily history tracking into SelfAuditor
+  component: auditor
+  dependencies: [9]
+  priority: 3
+  status: pending
+- id: 11
+  description: Orchestrator generates refactor tasks when SelfAuditor thresholds exceeded
+  component: orchestrator
+  dependencies: [9]
+  priority: 2
+  status: pending


### PR DESCRIPTION
## Summary
- deliver research brief about code quality analysis
- outline SelfAuditor API in `ARCHITECTURE.md`
- document radon/wily/pylint dependencies
- add SelfAuditor epic tasks

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68525a797638832a8a3163557bbdb4a0