### PR TITLE
Implement reflector integration tests and cleanup tasks

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -283,44 +283,8 @@
   - 42
   priority: 2
   status: done
-- id: 44
-  description: Refactor tests/test_bootstrap.py complexity 12
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 45
-  description: Refactor tests/test_planner.py complexity 24
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 46
-  description: Refactor tests/test_executor.py complexity 13
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 47
-  description: Refactor core/bootstrap.py complexity 15
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
 - id: 48
   description: Refactor core/planner.py complexity 41
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 49
-  description: Refactor core/orchestrator.py complexity 13
-  component: core
-  dependencies: []
-  priority: 3
-  status: pending
-- id: 50
-  description: Refactor core/reflector.py complexity 24
   component: core
   dependencies: []
   priority: 3
@@ -330,7 +294,7 @@
   component: maintenance
   dependencies: []
   priority: 2
-  status: pending
+  status: done
   metadata:
     type: technical_debt
     generated_by: Reflector
@@ -359,40 +323,6 @@
         task_ids:
         - 37
         - 46
-- id: 52
-  description: Clean up 5 duplicate tasks
-  component: maintenance
-  dependencies: []
-  priority: 2
-  status: pending
-  metadata:
-    type: technical_debt
-    generated_by: Reflector
-    decision_type: task_cleanup
-    details:
-      type: task_cleanup
-      reason: Duplicate tasks detected
-      duplicates:
-      - description: Refactor tests/test_bootstrap.py complexity 12
-        task_ids:
-        - 38
-        - 44
-      - description: Refactor tests/test_executor.py complexity 13
-        task_ids:
-        - 37
-        - 46
-      - description: Refactor core/bootstrap.py complexity 15
-        task_ids:
-        - 34
-        - 47
-      - description: Refactor core/orchestrator.py complexity 13
-        task_ids:
-        - 35
-        - 49
-      - description: Refactor core/reflector.py complexity 24
-        task_ids:
-        - 33
-        - 50
 - id: 53
   description: Document strategic research roadmap (RB-002)
   component: docs


### PR DESCRIPTION
## Summary
- refactor `Orchestrator` run loop into smaller helpers
- add integration test ensuring tasks file updates after reflection
- remove duplicate refactor tasks from `tasks.yml`

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852d5c484ec832a9eaf9365056a16ef