### PR TITLE
Add tasks for Reflector Core change requests

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -378,3 +378,85 @@
   - 53
   priority: 3
   status: pending
+- id: 61
+  description: Implement Experience Replay Buffer for PPO agent
+  component: reflector
+  dependencies: []
+  priority: 2
+  status: pending
+- id: 62
+  description: Integrate Elastic Weight Consolidation in training loop
+  component: reflector
+  dependencies:
+  - 61
+  priority: 3
+  status: pending
+- id: 63
+  description: Build state representation vector using observability data
+  component: reflector
+  dependencies: []
+  priority: 2
+  status: pending
+- id: 64
+  description: Implement generative action space via fine-tuned code LLM
+  component: reflector
+  dependencies:
+  - 63
+  priority: 3
+  status: pending
+- id: 65
+  description: Design composite reward function balancing correctness and performance
+  component: reflector
+  dependencies:
+  - 63
+  priority: 2
+  status: pending
+- id: 66
+  description: Develop PPO agent with actor-critic architecture
+  component: reflector
+  dependencies:
+  - 61
+  - 63
+  - 65
+  priority: 2
+  status: pending
+- id: 67
+  description: Implement Evolutionary Policy Optimization outer loop
+  component: reflector
+  dependencies:
+  - 66
+  priority: 3
+  status: pending
+- id: 68
+  description: Define gene structure for outer loop agent variation
+  component: reflector
+  dependencies:
+  - 67
+  priority: 3
+  status: pending
+- id: 69
+  description: Create high-fidelity simulation environment for code changes
+  component: infrastructure
+  dependencies: []
+  priority: 2
+  status: pending
+- id: 70
+  description: Integrate two-speed architecture connecting inner and outer loops
+  component: reflector
+  dependencies:
+  - 67
+  - 69
+  priority: 2
+  status: pending
+- id: 71
+  description: Develop standardized benchmarking suite for agent evaluation
+  component: tests
+  dependencies: []
+  priority: 3
+  status: pending
+- id: 72
+  description: Implement continuous improvement dashboard for key metrics
+  component: docs
+  dependencies: []
+  priority: 3
+  status: pending


### PR DESCRIPTION
## Summary
- add new tasks for Experience Replay, EWC, PPO agent and more

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e0be3380832a8ff58c0a05502c48