### PR TITLE
Add plugin and observability tasks

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -460,3 +460,133 @@
   dependencies: []
   priority: 3
   status: pending
+- id: 73
+  description: Define plugin APIs, isolation model, and threat analysis
+  component: plugins
+  dependencies: []
+  priority: 3
+  status: pending
+- id: 74
+  description: Document plugin governance requirements and dependency controls
+  component: docs
+  dependencies:
+  - 73
+  priority: 3
+  status: pending
+- id: 75
+  description: Add SAST, SCA, secret scanning, and compliance checks in CI/CD
+  component: ci
+  dependencies: []
+  priority: 2
+  status: pending
+- id: 76
+  description: Enforce cryptographic signing before plugin marketplace publication
+  component: ci
+  dependencies:
+  - 75
+  priority: 2
+  status: pending
+- id: 77
+  description: Build example first-party plugins (e.g., tech debt analyzer)
+  component: plugins
+  dependencies:
+  - 73
+  - 75
+  priority: 3
+  status: pending
+- id: 78
+  description: Validate plugin architecture and CI pipeline with first-party plugins
+  component: plugins
+  dependencies:
+  - 77
+  priority: 3
+  status: pending
+- id: 79
+  description: Instrument all components with OpenTelemetry for metrics, logs, and traces
+  component: observability
+  dependencies: []
+  priority: 3
+  status: pending
+- id: 80
+  description: Store metrics in Prometheus and define Grafana dashboards as code
+  component: observability
+  dependencies:
+  - 79
+  priority: 3
+  status: pending
+- id: 81
+  description: Feed collected metrics to Reflector as its reward signal
+  component: reflector
+  dependencies:
+  - 79
+  priority: 3
+  status: pending
+- id: 82
+  description: Introduce Rust modules via PyO3 for performance-critical code
+  component: microservices
+  dependencies: []
+  priority: 3
+  status: pending
+- id: 83
+  description: Add Node.js services for I/O-bound tasks and coordinate via gRPC
+  component: microservices
+  dependencies:
+  - 82
+  priority: 3
+  status: pending
+- id: 84
+  description: Apply API Gateway and Database-per-Service patterns
+  component: microservices
+  dependencies:
+  - 82
+  - 83
+  priority: 3
+  status: pending
+- id: 85
+  description: Ensure all microservices integrate with standardized OTel and security tooling
+  component: observability
+  dependencies:
+  - 79
+  - 82
+  - 83
+  priority: 3
+  status: pending
+- id: 86
+  description: Implement Vision Engine prioritization using WSJF heuristics
+  component: vision
+  dependencies: []
+  priority: 3
+  status: pending
+- id: 87
+  description: Train RL-based Vision Engine in shadow mode and gradually delegate control
+  component: vision
+  dependencies:
+  - 86
+  priority: 3
+  status: pending
+- id: 88
+  description: Build fast PPO-aligned Reflector inner loop for continuous improvement
+  component: reflector
+  dependencies: []
+  priority: 2
+  status: pending
+- id: 89
+  description: Develop evolutionary outer loop for architectural search
+  component: reflector
+  dependencies:
+  - 88
+  priority: 3
+  status: pending
+- id: 90
+  description: Contribute integration guides and sample code to frameworks like LangChain and CrewAI
+  component: docs
+  dependencies: []
+  priority: 3
+  status: pending
+- id: 91
+  description: Foster developer community to encourage adoption of AI-SWA
+  component: community
+  dependencies:
+  - 90
+  priority: 3
+  status: pending


### PR DESCRIPTION
## Summary
- extend tasks.yml with new tasks covering plugin security, observability, microservices, and vision components

## Testing
- `pip install -q -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e95acf80832a9baa08d24d2ad4e9