### PR TITLE
Integrate metrics into Reflector

### DIFF
--- a/core/observability.py
+++ b/core/observability.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, Optional
+
+
+class MetricsProvider:
+    """Simple provider for observability metrics."""
+
+    def __init__(self, metrics_path: Optional[Path] = None) -> None:
+        self.metrics_path = Path(metrics_path or "metrics.json")
+        self.logger = logging.getLogger(__name__)
+
+    def collect(self) -> Dict:
+        """Return metrics from ``metrics_path`` if available."""
+        if not self.metrics_path.exists():
+            self.logger.info("Metrics file %s not found", self.metrics_path)
+            return {}
+        try:
+            with self.metrics_path.open("r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as exc:  # pragma: no cover - IO issues
+            self.logger.warning("Failed to read metrics: %s", exc)
+            return {}
+

--- a/core/reflector.py
+++ b/core/reflector.py
@@ -10,6 +10,7 @@ from typing import Dict, List, Optional
 import yaml
 
 from .self_auditor import SelfAuditor
+from .observability import MetricsProvider
 
 
 class Reflector:
@@ -20,11 +21,13 @@ class Reflector:
         tasks_path: Path = Path("tasks.yml"),
         complexity_threshold: int = 15,
         analysis_paths: Optional[List[Path]] = None,
+        metrics_provider: Optional["MetricsProvider"] = None,
     ) -> None:
         self.tasks_path = Path(tasks_path)
         self.complexity_threshold = complexity_threshold
         self.analysis_paths = analysis_paths or self._discover_analysis_paths()
         self.self_auditor = SelfAuditor(complexity_threshold=complexity_threshold)
+        self.metrics_provider = metrics_provider
         self.logger = logging.getLogger(__name__)
 
     # ------------------------------------------------------------------
@@ -70,6 +73,9 @@ class Reflector:
         analysis["system_health"] = self._analyze_system_health()
         analysis["evolution_trends"] = self._analyze_evolution_trends()
         analysis["strategic_insights"] = self._generate_strategic_insights(analysis)
+
+        if self.metrics_provider:
+            analysis["observability_metrics"] = self.metrics_provider.collect()
 
         return analysis
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -520,7 +520,7 @@
   dependencies:
   - 79
   priority: 3
-  status: pending
+  status: done
 - id: 82
   description: Introduce Rust modules via PyO3 for performance-critical code
   component: microservices

--- a/tests/test_reflector.py
+++ b/tests/test_reflector.py
@@ -29,3 +29,32 @@ def func(x):
     assert isinstance(result, list)
     updated = yaml.safe_load(tasks_file.read_text())
     assert isinstance(updated, list)
+
+from core.observability import MetricsProvider
+
+
+def test_reflector_collects_metrics(tmp_path):
+    tasks_file = tmp_path / "tasks.yml"
+    tasks_file.write_text(
+        "- id: 1\n"
+        "  description: base\n"
+        "  component: core\n"
+        "  dependencies: []\n"
+        "  priority: 1\n"
+        "  status: pending\n"
+    )
+    code_file = tmp_path / "code.py"
+    code_file.write_text("def foo():\n    return 1\n")
+    metrics_file = tmp_path / "metrics.json"
+    metrics_file.write_text('{"coverage": 90}')
+
+    provider = MetricsProvider(metrics_file)
+    refl = Reflector(
+        tasks_path=tasks_file,
+        complexity_threshold=1,
+        analysis_paths=[code_file],
+        metrics_provider=provider,
+    )
+    analysis = refl.analyze()
+    assert analysis.get("observability_metrics") == {"coverage": 90}
+


### PR DESCRIPTION
## Summary
- add `MetricsProvider` to supply collected metrics
- inject observability metrics into `Reflector`
- test metrics collection logic
- mark task 81 complete

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68535b3b4bec832a8258f7f2ddbf6278