### PR TITLE
Implement OTel metrics pipeline

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -10,6 +10,7 @@ from .planner import Planner
 from .executor import Executor
 from .reflector import Reflector
 from .self_auditor import SelfAuditor
+from .telemetry import setup_telemetry
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -27,6 +28,8 @@ def main(argv=None):
     """Run the orchestrator using arguments from ``argv``."""
     parser = build_parser()
     args = parser.parse_args(argv)
+
+    setup_telemetry()
 
     memory = Memory(Path(args.memory))
     try:

--- a/core/executor.py
+++ b/core/executor.py
@@ -4,10 +4,23 @@ import subprocess
 import shlex
 from datetime import datetime
 from pathlib import Path
+import time
+
+from opentelemetry import metrics, trace
 
 
 class Executor:
     """Carry out tasks and capture their output."""
+
+    def __init__(self) -> None:
+        meter = metrics.get_meter_provider().get_meter(__name__)
+        self._tasks_executed = meter.create_counter(
+            "tasks_executed_total", description="Number of executed tasks"
+        )
+        self._task_duration = meter.create_histogram(
+            "task_duration_seconds", description="Task execution duration"
+        )
+        self._tracer = trace.get_tracer(__name__)
 
     def execute(self, task: object) -> None:
         """Execute ``task`` and write any command output to ``logs/``.
@@ -34,10 +47,18 @@ class Executor:
         if not command:
             return
 
-        args = shlex.split(command)
-        result = subprocess.run(args, capture_output=True, text=True)
+        attrs = {"task.id": getattr(task, "id", "unknown")}
+        start_time = time.perf_counter()
+        with self._tracer.start_as_current_span("executor.execute", attributes=attrs):
+            args = shlex.split(command)
+            result = subprocess.run(args, capture_output=True, text=True)
+        duration = time.perf_counter() - start_time
+
         timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
         log_dir = Path("logs")
         log_dir.mkdir(exist_ok=True)
         log_file = log_dir / f"task-{getattr(task, 'id', 'unknown')}-{timestamp}.log"
         log_file.write_text(result.stdout + result.stderr)
+
+        self._tasks_executed.add(1, attrs)
+        self._task_duration.record(duration, attrs)

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -1,0 +1,41 @@
+"""OpenTelemetry setup utilities for AI-SWA."""
+
+from __future__ import annotations
+
+import logging
+from typing import Tuple
+
+from opentelemetry import metrics, trace
+from opentelemetry.metrics import set_meter_provider, get_meter_provider
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.exporter.prometheus import PrometheusMetricReader, start_http_server
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogExporter
+
+
+def setup_telemetry(service_name: str = "ai_swa", metrics_port: int = 8000) -> Tuple[object, object]:
+    """Configure OpenTelemetry providers and start the Prometheus metrics server."""
+
+    resource = Resource.create({"service.name": service_name})
+
+    # Metrics provider with Prometheus exporter
+    reader = PrometheusMetricReader()
+    meter_provider = MeterProvider(metric_readers=[reader], resource=resource)
+    set_meter_provider(meter_provider)
+    server, thread = start_http_server(port=metrics_port)
+
+    # Tracing provider with console exporter
+    tracer_provider = TracerProvider(resource=resource)
+    tracer_provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    trace.set_tracer_provider(tracer_provider)
+
+    # Logging provider with console exporter
+    logger_provider = LoggerProvider(resource=resource)
+    logger_provider.add_log_record_processor(BatchLogRecordProcessor(ConsoleLogExporter()))
+    handler = LoggingHandler(level=logging.INFO, logger_provider=logger_provider)
+    logging.getLogger().addHandler(handler)
+
+    return server, thread

--- a/grafana/dashboard.py
+++ b/grafana/dashboard.py
@@ -1,0 +1,19 @@
+from grafanalib.core import Dashboard, Graph, Row, Target
+from grafanalib.prometheus import PromQL
+
+DASHBOARD = Dashboard(
+    title="AI-SWA Overview",
+    rows=[
+        Row(panels=[
+            Graph(
+                title="Tasks Executed",
+                dataSource="Prometheus",
+                targets=[Target(expr="tasks_executed_total", legendFormat="executed")],
+            )
+        ])
+    ],
+).auto_panel_ids()
+
+if __name__ == "__main__":
+    import json
+    print(json.dumps(DASHBOARD.to_json_data(), indent=2))

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ pylint==3.3.7
 fastapi==0.111.0
 uvicorn==0.29.0
 requests==2.31.0
+opentelemetry-sdk==1.34.1
+opentelemetry-exporter-prometheus==0.55b1
+grafanalib==0.7.1

--- a/tasks.yml
+++ b/tasks.yml
@@ -506,14 +506,14 @@
   component: observability
   dependencies: []
   priority: 3
-  status: pending
+  status: done
 - id: 80
   description: Store metrics in Prometheus and define Grafana dashboards as code
   component: observability
   dependencies:
   - 79
   priority: 3
-  status: pending
+  status: done
 - id: 81
   description: Feed collected metrics to Reflector as its reward signal
   component: reflector

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,11 @@
+import requests
+from core.telemetry import setup_telemetry
+
+
+def test_setup_telemetry() -> None:
+    server, _ = setup_telemetry(metrics_port=0)
+    try:
+        response = requests.get(f"http://localhost:{server.server_port}/metrics")
+        assert response.status_code == 200
+    finally:
+        server.shutdown()


### PR DESCRIPTION
## Summary
- instrument executor and orchestrator with OpenTelemetry
- expose metrics via Prometheus exporter and hook into CLI
- add telemetry setup helper and tests
- document Grafana dashboard as code
- update tasks

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68535b58b30c832a8172b31eb8b7ca87