### PR TITLE
Embed task schema header

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ Your mission is to parse this document, form your plan, and then execute the ins
             #         "component": {"type": "string"},
             #         "dependencies": {"type": "array","items":{"type":"integer"}},
             #         "priority": {"type": "integer","minimum":1,"maximum":5},
-            #         "status": {"type":"string","enum":["pending","in_progress","done"]}
+            #         "status": {"type":"string","enum":["pending","in_progress","done"]},
+            #         "command": {"type": ["string", "null"]}
             #       }
             #     }
             #   }

--- a/tasks.yml
+++ b/tasks.yml
@@ -1,3 +1,21 @@
+# jsonschema: |
+#   {
+#     "$schema": "http://json-schema.org/draft-07/schema#",
+#     "type": "array",
+#     "items": {
+#       "type": "object",
+#       "required": ["id","description","component","dependencies","priority","status"],
+#       "properties": {
+#         "id": {"type": "integer"},
+#         "description": {"type": "string"},
+#         "component": {"type": "string"},
+#         "dependencies": {"type": "array","items": {"type": "integer"}},
+#         "priority": {"type": "integer","minimum": 1, "maximum": 5},
+#         "status": {"type": "string","enum": ["pending","in_progress","done"]},
+#         "command": {"type": ["string", "null"]}
+#       }
+#     }
+#   }
 - id: 1
   description: Implement YAML validation using jsonschema
   component: bootstrap


### PR DESCRIPTION
## Summary
- add JSON schema comment header to `tasks.yml`
- document `command` field in tasks schema example

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6853668efffc832a83acb83c97ce94c2