### PR TITLE
Add contributing guide for installing requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,26 @@
+# Contributing Guide
+
+This project uses pinned dependencies listed in `requirements.txt` for consistent environments.
+
+## Setting up your environment
+
+Before running tests or using pre-commit hooks, install the exact package versions:
+
+```bash
+pip install -r requirements.txt
+```
+
+To enable automatic checks, optionally install and configure pre-commit:
+
+```bash
+pre-commit install
+```
+
+## Running tests
+
+After installing the dependencies, run the tests to verify your changes:
+
+```bash
+pytest --maxfail=1 --disable-warnings -q
+```
+

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Planner decides what to build next. The Executor writes files and configures CI/
 2. Build a plugin or propose an improvement.
 3. Add tests and update the planner to include your feature.
 4. Submit a pull request with a clear rationale.
+5. See `CONTRIBUTING.md` for installing pinned dependencies and running tests.
 
 Ready to witness a software architect that codes, tests, and evolves itself? Dive in and help shape the future of autonomous development.
 


### PR DESCRIPTION
## Summary
- create `CONTRIBUTING.md` with instructions on installing the pinned requirements and optional `pre-commit` hooks
- link to the new guide from the `README`

## Testing
- `pip install -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68536dd29bc4832a8c7f2718cdac75d9