### PR TITLE
Add API docstring in broker

### DIFF
--- a/broker/main.py
+++ b/broker/main.py
@@ -1,3 +1,18 @@
+"""Task broker API backed by SQLite.
+
+The service exposes a minimal REST interface for managing tasks and their
+execution results:
+
+* ``POST /tasks`` creates a new task entry.
+* ``GET /tasks`` lists all tasks.
+* ``GET /tasks/{id}`` retrieves a single task.
+* ``POST /tasks/{id}/result`` stores stdout, stderr and exit code.
+
+All data is persisted in a SQLite database specified by ``DB_PATH``. Two tables
+are created on startup: ``tasks`` for task metadata and ``task_results`` for
+worker output.
+"""
+
 import os
 import sqlite3
 from fastapi import FastAPI, HTTPException


### PR DESCRIPTION
## Summary
- document FastAPI endpoints and database usage in `broker/main.py`

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68536dc1c970832a8689f331d13cb9d0