### PR TITLE
Implement RL training pipeline using observability metrics

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -630,7 +630,7 @@
   - 87
   - 85
   priority: 3
-  status: pending
+  status: done
 - id: 95
   description: Run RL agent in shadow mode and log suggestions
   component: vision

--- a/tests/test_rl_training.py
+++ b/tests/test_rl_training.py
@@ -1,0 +1,13 @@
+from core.observability import MetricsProvider
+from vision.vision_engine import RLAgent
+from vision.training import RLTrainer
+
+
+def test_rl_trainer_runs(tmp_path):
+    metrics_file = tmp_path / "metrics.json"
+    metrics_file.write_text('{"coverage": 85}')
+    provider = MetricsProvider(metrics_file)
+    agent = RLAgent()
+    trainer = RLTrainer(agent=agent, metrics_provider=provider)
+    trainer.run()
+    assert agent.training_data == [{"coverage": 85}]

--- a/vision/__init__.py
+++ b/vision/__init__.py
@@ -1,5 +1,6 @@
 """Vision Engine package."""
 
 from .vision_engine import VisionEngine, RLAgent, wsjf_score
+from .training import RLTrainer
 
-__all__ = ["VisionEngine", "RLAgent", "wsjf_score"]
+__all__ = ["VisionEngine", "RLAgent", "wsjf_score", "RLTrainer"]

--- a/vision/training.py
+++ b/vision/training.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+"""Simple RL training pipeline for the Vision Engine."""
+
+from dataclasses import dataclass
+
+from core.observability import MetricsProvider
+from .vision_engine import RLAgent
+
+
+@dataclass
+class RLTrainer:
+    """Train an :class:`RLAgent` using observability metrics."""
+
+    agent: RLAgent
+    metrics_provider: MetricsProvider
+
+    def run(self) -> None:
+        """Collect metrics and pass them to the agent's training routine."""
+        metrics = self.metrics_provider.collect()
+        self.agent.train(metrics)

--- a/vision/vision_engine.py
+++ b/vision/vision_engine.py
@@ -49,6 +49,7 @@ class RLAgent:
 
     def __init__(self) -> None:
         self.history: List[Dict[str, List[int]]] = []
+        self.training_data: List[Dict[str, float]] = []
 
     def suggest(self, tasks: List[Task]) -> List[Task]:
         """Return refined ordering. Currently identity function."""
@@ -63,5 +64,6 @@ class RLAgent:
             }
         )
 
-    def train(self) -> None:  # pragma: no cover - placeholder for future training
-        pass
+    def train(self, metrics: Dict[str, float]) -> None:
+        """Collect ``metrics`` for offline training."""
+        self.training_data.append(metrics)


### PR DESCRIPTION
## Summary
- mark RL training task in progress then done
- add RL training pipeline implementation
- export `RLTrainer`
- capture training metrics in `RLAgent`
- test RL trainer

## Testing
- `pip install -q -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68538b258438832abe543fcc45213c3b