### PR TITLE
Implement WSJF CLI and tests

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -622,7 +622,7 @@
   dependencies:
   - 86
   priority: 3
-  status: pending
+  status: done
 - id: 94
   description: Implement RL training pipeline using observability metrics
   component: vision

--- a/tests/test_vision_cli.py
+++ b/tests/test_vision_cli.py
@@ -1,0 +1,74 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def _task(id, ubv, tc, rr, size):
+    return {
+        "id": id,
+        "description": "",
+        "component": "vision",
+        "dependencies": [],
+        "priority": 1,
+        "status": "pending",
+        "user_business_value": ubv,
+        "time_criticality": tc,
+        "risk_reduction": rr,
+        "job_size": size,
+    }
+
+
+def test_vision_cli_ranking(tmp_path):
+    tasks = [
+        _task(1, 10, 2, 1, 5),  # score 2.6
+        _task(2, 5, 1, 1, 2),   # score 3.5
+        _task(3, 8, 0, 0, 4),   # score 2.0
+    ]
+    tasks_file = tmp_path / "tasks.yml"
+    tasks_file.write_text(yaml.safe_dump(tasks, sort_keys=False))
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    result = subprocess.run(
+        [sys.executable, "-m", "vision.cli", str(tasks_file)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0
+    ordered = yaml.safe_load(result.stdout)
+    assert [item["id"] for item in ordered] == [2, 1, 3]
+
+
+def test_vision_cli_help(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    result = subprocess.run(
+        [sys.executable, "-m", "vision.cli", "--help"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "usage" in result.stdout.lower()
+
+
+def test_vision_cli_missing_file(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    result = subprocess.run(
+        [sys.executable, "-m", "vision.cli", str(tmp_path / "missing.yml")],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode != 0

--- a/vision/cli.py
+++ b/vision/cli.py
@@ -1,0 +1,43 @@
+"""Command line interface for WSJF task ranking."""
+
+import argparse
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import yaml
+
+from .vision_engine import wsjf_score
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Return argument parser for the CLI."""
+    parser = argparse.ArgumentParser(description="Rank tasks using WSJF scoring")
+    parser.add_argument(
+        "tasks_file",
+        help="Path to YAML file containing tasks with WSJF fields",
+    )
+    return parser
+
+
+def main(argv=None) -> int:
+    """Run the WSJF ranking CLI."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    path = Path(args.tasks_file)
+    if not path.exists():
+        print(f"Tasks file not found: {path}", file=sys.stderr)
+        return 1
+    data = yaml.safe_load(path.read_text()) or []
+    tasks = [SimpleNamespace(**item) for item in data]
+    scored = [
+        {"id": item.get("id"), "wsjf": wsjf_score(task)}
+        for item, task in zip(data, tasks)
+    ]
+    scored.sort(key=lambda x: x["wsjf"], reverse=True)
+    yaml.safe_dump(scored, sys.stdout, sort_keys=False)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add CLI to rank tasks by WSJF score
- add tests for vision CLI
- mark task 93 done in tasks.yml

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68538b18a898832aa6e1afba7a1eaeb4