### PR TITLE
Implement RL shadow logging and authority escalation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -298,6 +298,18 @@ Each worker fetches the pending tasks via HTTP and executes any
 ``command`` attribute inside an isolated sandbox. A minimal Dockerfile
 installs the project requirements and launches ``worker/main.py``.
 
+### Vision Engine
+Ranks epics using Weighted Shortest Job First (WSJF) scores. An optional
+``RLAgent`` can refine this ordering. The agent begins in **shadow mode**
+where its suggestions are logged but not applied. Logged suggestions are
+stored in JSON lines so that offline training can analyse how the agent
+would have re-ranked tasks.
+
+The ``RLAgent`` tracks an ``authority`` value from ``0.0`` to ``1.0``. The
+``VisionEngine`` applies the agent's ordering to the top fraction of tasks
+equal to this authority. The value only increases when observed
+performance gains exceed a threshold, allowing gradual delegation.
+
 ## Dependencies
 - **PyYAML==6.0.1** - Safe YAML parsing
 - **pytest==7.4.0** - Test execution

--- a/tasks.yml
+++ b/tasks.yml
@@ -637,11 +637,11 @@
   dependencies:
   - 94
   priority: 3
-  status: pending
+  status: done
 - id: 96
   description: Gradually enable RL authority based on performance gains
   component: vision
   dependencies:
   - 95
   priority: 3
-  status: pending
+  status: done

--- a/tests/test_vision_engine.py
+++ b/tests/test_vision_engine.py
@@ -1,9 +1,16 @@
 import unittest
+import json
+import tempfile
+from pathlib import Path
+
 from core.task import Task
 from vision.vision_engine import VisionEngine, RLAgent
 
 
 class TestVisionEngine(unittest.TestCase):
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+
     def _task(self, id, ubv, tc, rr, size):
         t = Task(
             id=id,
@@ -35,3 +42,28 @@ class TestVisionEngine(unittest.TestCase):
         ve.prioritize([t1, t2])
         self.assertEqual(len(agent.history), 1)
         self.assertEqual(agent.history[0]["baseline"], [1, 2])
+
+    def test_rl_shadow_mode_logs_to_file(self):
+        log_file = Path(self.tmpdir) / "history.log"
+        agent = RLAgent(history_path=log_file)
+        ve = VisionEngine(rl_agent=agent, shadow_mode=True)
+        t1 = self._task(1, 1, 1, 1, 1)
+        ve.prioritize([t1])
+        self.assertTrue(log_file.exists())
+        data = json.loads(log_file.read_text().strip())
+        self.assertEqual(data["baseline"], [1])
+
+    def test_rl_authority_applies_partial_order(self):
+        class DummyAgent(RLAgent):
+            def suggest(self, tasks):
+                return list(reversed(tasks))
+
+        agent = DummyAgent()
+        ve = VisionEngine(rl_agent=agent, shadow_mode=False)
+        agent.authority = 0.5
+        t1 = self._task(1, 4, 2, 1, 1)
+        t2 = self._task(2, 2, 1, 0, 1)
+        t3 = self._task(3, 1, 0, 0, 1)
+        ordered = ve.prioritize([t1, t2, t3])
+        self.assertEqual([t.id for t in ordered], [3, 1, 2])
+

--- a/vision/vision_engine.py
+++ b/vision/vision_engine.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List, Dict, Optional
+import json
 
 from core.task import Task
 
@@ -37,19 +39,29 @@ class VisionEngine:
 
     def _maybe_refine_with_rl(self, tasks: List[Task]) -> List[Task]:
         suggestions = self.rl_agent.suggest(tasks)
-        if self.shadow_mode:
+        if self.shadow_mode or self.rl_agent.authority <= 0:
             # Log but do not alter ordering
             self.rl_agent.record_shadow_result(tasks, suggestions)
             return tasks
-        return suggestions
+
+        if self.rl_agent.authority >= 1:
+            return suggestions
+
+        # Apply RL ordering to a fraction of tasks equal to authority
+        n = int(len(tasks) * self.rl_agent.authority)
+        top_rl = suggestions[:n]
+        remaining = [t for t in tasks if t not in top_rl]
+        return top_rl + remaining
 
 
 class RLAgent:
     """Minimal stub of an RL agent for prioritization."""
 
-    def __init__(self) -> None:
+    def __init__(self, history_path: Optional[Path] = None) -> None:
         self.history: List[Dict[str, List[int]]] = []
         self.training_data: List[Dict[str, float]] = []
+        self.history_path = Path(history_path) if history_path else None
+        self.authority: float = 0.0
 
     def suggest(self, tasks: List[Task]) -> List[Task]:
         """Return refined ordering. Currently identity function."""
@@ -57,13 +69,20 @@ class RLAgent:
 
     def record_shadow_result(self, baseline: List[Task], suggestion: List[Task]) -> None:
         """Store comparison between baseline and suggestion for offline training."""
-        self.history.append(
-            {
-                "baseline": [t.id for t in baseline],
-                "suggestion": [t.id for t in suggestion],
-            }
-        )
+        entry = {
+            "baseline": [t.id for t in baseline],
+            "suggestion": [t.id for t in suggestion],
+        }
+        self.history.append(entry)
+        if self.history_path:
+            with self.history_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(entry) + "\n")
 
     def train(self, metrics: Dict[str, float]) -> None:
         """Collect ``metrics`` for offline training."""
         self.training_data.append(metrics)
+
+    def update_authority(self, performance_gain: float, threshold: float = 0.05) -> None:
+        """Increase authority when ``performance_gain`` exceeds ``threshold``."""
+        if performance_gain > threshold:
+            self.authority = min(1.0, self.authority + performance_gain)


### PR DESCRIPTION
## Summary
- mark task 95 in progress then complete tasks 95 and 96
- document Vision Engine RL flow in architecture
- extend VisionEngine and RLAgent with shadow logging and gradual authority
- add tests for new RL behaviour

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68538f3263b0832ab1e7b0350ea26054