### PR TITLE
Implement plugin permission validation

### DIFF
--- a/core/plugins.py
+++ b/core/plugins.py
@@ -1,0 +1,49 @@
+"""Plugin management utilities with permission validation."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import List
+
+from .security import validate_plugin_permissions, verify_plugin_signature
+
+
+@dataclass
+class PluginManifest:
+    """Metadata describing a plugin."""
+
+    id: str
+    name: str
+    version: str
+    permissions: List[str]
+    signature: str | None = None
+
+    def data_for_signature(self) -> dict:
+        data = asdict(self)
+        data.pop("signature", None)
+        return data
+
+
+def load_manifest(path: Path) -> PluginManifest:
+    """Load and validate a plugin manifest from ``path``."""
+    with open(path, "r") as f:
+        data = json.load(f)
+    manifest = PluginManifest(**data)
+    validate_plugin_permissions(manifest.permissions)
+    if manifest.signature:
+        verify_plugin_signature(manifest.data_for_signature(), manifest.signature)
+    else:
+        if os.getenv("PLUGIN_SIGNING_KEY"):
+            raise ValueError("Signature required")
+    return manifest
+
+
+def discover_plugins(plugin_dir: Path) -> list[PluginManifest]:
+    """Return manifests for all plugins in ``plugin_dir``."""
+    manifests: list[PluginManifest] = []
+    for manifest_file in plugin_dir.glob("*/manifest.json"):
+        manifests.append(load_manifest(manifest_file))
+    return manifests

--- a/docs/plugins/permissions.md
+++ b/docs/plugins/permissions.md
@@ -1,0 +1,13 @@
+# Plugin Permissions Model
+
+Plugins must declare a manifest file named `manifest.json` that specifies the plugin
+metadata and requested permissions. Each manifest includes:
+
+- `id`, `name`, and `version` fields.
+- `permissions`: a list of capabilities the plugin requires (e.g. `read_files`, `network`).
+- Optional `signature`: an HMAC-SHA256 signature of the manifest contents.
+
+The host validates that all requested permissions are allowed and, when a signing
+key is configured via the `PLUGIN_SIGNING_KEY` environment variable, verifies the
+signature. Plugins lacking a valid signature are rejected when signing is
+enabled.

--- a/plugins/example_plugin/manifest.json
+++ b/plugins/example_plugin/manifest.json
@@ -1,0 +1,6 @@
+{
+  "id": "example",
+  "name": "Example Plugin",
+  "version": "0.1.0",
+  "permissions": ["read_files"]
+}

--- a/plugins/example_plugin/plugin.py
+++ b/plugins/example_plugin/plugin.py
@@ -1,0 +1,4 @@
+"""Example plugin used for tests and documentation."""
+
+def run():
+    print("Example plugin executed")

--- a/tests/test_plugin_security.py
+++ b/tests/test_plugin_security.py
@@ -1,0 +1,60 @@
+import os
+import json
+import base64
+import hashlib
+import hmac
+import pytest
+from pathlib import Path
+
+from core.plugins import load_manifest, PluginManifest
+
+
+def sign(data: dict, key: str) -> str:
+    payload = json.dumps(data, sort_keys=True).encode()
+    return base64.b64encode(hmac.new(key.encode(), payload, hashlib.sha256).digest()).decode()
+
+
+def test_load_valid_manifest(tmp_path):
+    key = "secret"
+    os.environ["PLUGIN_SIGNING_KEY"] = key
+    data = {
+        "id": "demo",
+        "name": "Demo Plugin",
+        "version": "0.1",
+        "permissions": ["read_files"],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({**data, "signature": sign(data, key)}))
+    manifest = load_manifest(manifest_path)
+    assert manifest.id == "demo"
+    os.environ.pop("PLUGIN_SIGNING_KEY")
+
+
+def test_reject_invalid_permission(tmp_path):
+    data = {
+        "id": "demo",
+        "name": "Demo Plugin",
+        "version": "0.1",
+        "permissions": ["dangerous"],
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(data))
+    with pytest.raises(ValueError):
+        load_manifest(manifest_path)
+
+
+def test_reject_invalid_signature(tmp_path):
+    key = "secret"
+    os.environ["PLUGIN_SIGNING_KEY"] = key
+    data = {
+        "id": "demo",
+        "name": "Demo Plugin",
+        "version": "0.1",
+        "permissions": ["read_files"],
+        "signature": "bad",
+    }
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(data))
+    with pytest.raises(ValueError):
+        load_manifest(manifest_path)
+    os.environ.pop("PLUGIN_SIGNING_KEY")


### PR DESCRIPTION
## Summary
- add simple plugin loading and manifest validation
- enforce allowed permissions and optional signature via `PLUGIN_SIGNING_KEY`
- document plugin permissions model
- include example plugin
- test plugin validation logic

## Testing
- `pip install -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686a4a0e9090832a9b21adc11a1c8405