### PR TITLE
Expand VisionEngine edge case tests

### DIFF
--- a/tests/test_vision_engine.py
+++ b/tests/test_vision_engine.py
@@ -67,3 +67,51 @@ class TestVisionEngine(unittest.TestCase):
         ordered = ve.prioritize([t1, t2, t3])
         self.assertEqual([t.id for t in ordered], [3, 1, 2])
 
+    def test_wsjf_handles_missing_metrics(self):
+        """Tasks missing WSJF metrics should default to zero/one."""
+        t1 = Task(
+            id=1,
+            description="",
+            component="vision",
+            dependencies=[],
+            priority=1,
+            status="pending",
+        )
+        t2 = self._task(2, 1, 1, 1, 2)
+        ve = VisionEngine()
+        ordered = ve.prioritize([t1, t2])
+        self.assertEqual([t.id for t in ordered], [2, 1])
+
+    def test_wsjf_zero_and_negative_job_size(self):
+        """Zero job size defaults to one and negative values rank lowest."""
+        t_zero = self._task(1, 4, 2, 1, 0)  # treated as size 1 => high score
+        t_neg = self._task(2, 5, 0, 0, -2)  # negative size => negative score
+        ve = VisionEngine()
+        ordered = ve.prioritize([t_neg, t_zero])
+        self.assertEqual([t.id for t in ordered], [1, 2])
+
+    def test_rl_authority_full_ordering(self):
+        """Authority of 1 should fully apply RL suggestions."""
+
+        class ReverseAgent(RLAgent):
+            def suggest(self, tasks):
+                return list(reversed(tasks))
+
+        agent = ReverseAgent()
+        agent.authority = 1.0
+        ve = VisionEngine(rl_agent=agent, shadow_mode=False)
+        t1 = self._task(1, 1, 1, 1, 1)
+        t2 = self._task(2, 1, 1, 1, 1)
+        ordered = ve.prioritize([t1, t2])
+        self.assertEqual([t.id for t in ordered], [2, 1])
+
+    def test_rl_update_authority(self):
+        """update_authority increases authority only on sufficient gain."""
+        agent = RLAgent()
+        agent.update_authority(0.1)
+        self.assertAlmostEqual(agent.authority, 0.1)
+        agent.update_authority(0.01)
+        self.assertAlmostEqual(agent.authority, 0.1)
+        agent.update_authority(0.95)
+        self.assertLessEqual(agent.authority, 1.0)
+


### PR DESCRIPTION
## Summary
- extend VisionEngine tests for missing metrics and invalid data
- cover RLAgent authority handling and update logic

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686a4fadcb54832aa55986fb560e2b01