### PR TITLE
Centralize configuration

### DIFF
--- a/broker/main.py
+++ b/broker/main.py
@@ -13,18 +13,19 @@ are created on startup: ``tasks`` for task metadata and ``task_results`` for
 worker output.
 """
 
-import os
 import sqlite3
 from fastapi import FastAPI, HTTPException, Depends
 from pydantic import BaseModel
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from core.telemetry import setup_telemetry
 from core.security import verify_api_key, require_role, User
+from core.config import load_config
 
-DB_PATH = os.environ.get("DB_PATH", "tasks.db")
+config = load_config()
+DB_PATH = config["broker"]["db_path"]
 
 app = FastAPI()
-setup_telemetry(service_name="broker", metrics_port=int(os.getenv("METRICS_PORT", "9000")))
+setup_telemetry(service_name="broker", metrics_port=int(config["broker"]["metrics_port"]))
 FastAPIInstrumentor.instrument_app(app)
 
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,10 @@
+broker:
+  db_path: tasks.db
+  metrics_port: 9000
+worker:
+  broker_url: http://broker:8000
+  metrics_port: 9001
+security:
+  api_key: null
+  api_tokens: null
+  plugin_signing_key: null

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,50 @@
+"""Configuration loader for AI-SWA services."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import yaml
+
+DEFAULT_CONFIG = {
+    "broker": {"db_path": "tasks.db", "metrics_port": 9000},
+    "worker": {"broker_url": "http://broker:8000", "metrics_port": 9001},
+    "security": {"api_key": None, "api_tokens": None, "plugin_signing_key": None},
+}
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
+
+
+def load_config(path: str | Path | None = None) -> dict:
+    """Return configuration merged with environment overrides."""
+    cfg_path = Path(os.getenv("CONFIG_FILE", path or CONFIG_PATH))
+    data: dict = {}
+    if cfg_path.exists():
+        with cfg_path.open() as f:
+            data = yaml.safe_load(f) or {}
+    cfg = {
+        "broker": {**DEFAULT_CONFIG["broker"], **data.get("broker", {})},
+        "worker": {**DEFAULT_CONFIG["worker"], **data.get("worker", {})},
+        "security": {**DEFAULT_CONFIG["security"], **data.get("security", {})},
+    }
+
+    if "DB_PATH" in os.environ:
+        cfg["broker"]["db_path"] = os.environ["DB_PATH"]
+    if "BROKER_URL" in os.environ:
+        cfg["worker"]["broker_url"] = os.environ["BROKER_URL"]
+    if "BROKER_METRICS_PORT" in os.environ:
+        cfg["broker"]["metrics_port"] = int(os.environ["BROKER_METRICS_PORT"])
+    if "WORKER_METRICS_PORT" in os.environ:
+        cfg["worker"]["metrics_port"] = int(os.environ["WORKER_METRICS_PORT"])
+    if "METRICS_PORT" in os.environ:
+        port = int(os.environ["METRICS_PORT"])
+        cfg["broker"]["metrics_port"] = port
+        cfg["worker"]["metrics_port"] = port
+    if "API_KEY" in os.environ:
+        cfg["security"]["api_key"] = os.environ["API_KEY"]
+    if "API_TOKENS" in os.environ:
+        cfg["security"]["api_tokens"] = os.environ["API_TOKENS"]
+    if "PLUGIN_SIGNING_KEY" in os.environ:
+        cfg["security"]["plugin_signing_key"] = os.environ["PLUGIN_SIGNING_KEY"]
+
+    return cfg

--- a/core/plugins.py
+++ b/core/plugins.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import json
-import os
 from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import List
 
 from .security import validate_plugin_permissions, verify_plugin_signature
+from .config import load_config
 
 
 @dataclass
@@ -36,7 +36,7 @@ def load_manifest(path: Path) -> PluginManifest:
     if manifest.signature:
         verify_plugin_signature(manifest.data_for_signature(), manifest.signature)
     else:
-        if os.getenv("PLUGIN_SIGNING_KEY"):
+        if load_config()["security"].get("plugin_signing_key"):
             raise ValueError("Signature required")
     return manifest
 

--- a/core/security.py
+++ b/core/security.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import os
 import json
 from dataclasses import dataclass
 from fastapi import Header, HTTPException, Depends
+from .config import load_config
 
 
 @dataclass
@@ -16,15 +16,15 @@ class User:
     role: str
 
 def verify_api_key(x_api_key: str | None = Header(None)) -> None:
-    """Verify the ``X-API-Key`` header if ``API_KEY`` is configured."""
-    api_key = os.getenv("API_KEY")
+    """Verify the ``X-API-Key`` header if an API key is configured."""
+    api_key = load_config()["security"].get("api_key")
     if api_key and x_api_key != api_key:
         raise HTTPException(status_code=401, detail="Invalid API key")
 
 
 def _parse_tokens() -> dict[str, User]:
     """Return mapping of authentication tokens to ``User`` objects."""
-    env = os.getenv("API_TOKENS")
+    env = load_config()["security"].get("api_tokens")
     if not env:
         return {}
     tokens: dict[str, User] = {}
@@ -74,7 +74,7 @@ def validate_plugin_permissions(perms: list[str]) -> None:
 
 def verify_plugin_signature(manifest: dict, signature: str) -> None:
     """Verify plugin manifest signature if signing key is configured."""
-    key = os.getenv("PLUGIN_SIGNING_KEY")
+    key = load_config()["security"].get("plugin_signing_key")
     if not key:
         return
     import base64


### PR DESCRIPTION
## Summary
- add `config.yaml` with defaults for broker, worker and security settings
- implement `core.config.load_config` helper to merge YAML and env vars
- update broker, worker and core modules to use centralized configuration

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686a51ec5ee4832aafa78f891a104a2d