### PR TITLE
Add optional metadata support to tasks

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -33,6 +33,13 @@ TASK_SCHEMA = {
                 "enum": ["pending", "in_progress", "done"],
             },
             "command": {"type": ["string", "null"]},
+            "task_id": {"type": "string"},
+            "title": {"type": "string"},
+            "area": {"type": "string"},
+            "actionable_steps": {"type": "array", "items": {"type": "string"}},
+            "acceptance_criteria": {"type": "array", "items": {"type": "string"}},
+            "assigned_to": {"type": ["string", "null"]},
+            "epic": {"type": "string"},
         },
     },
 }

--- a/core/task.py
+++ b/core/task.py
@@ -13,3 +13,11 @@ class Task:
     priority: int
     status: str
     command: Optional[str] = None
+    # Optional extended metadata
+    task_id: Optional[str] = None
+    title: Optional[str] = None
+    area: Optional[str] = None
+    actionable_steps: Optional[List[str]] = None
+    acceptance_criteria: Optional[List[str]] = None
+    assigned_to: Optional[str] = None
+    epic: Optional[str] = None

--- a/tasks.yml
+++ b/tasks.yml
@@ -12,7 +12,14 @@
 #         "dependencies": {"type": "array","items": {"type": "integer"}},
 #         "priority": {"type": "integer","minimum": 1, "maximum": 5},
 #         "status": {"type": "string","enum": ["pending","in_progress","done"]},
-#         "command": {"type": ["string", "null"]}
+#         "command": {"type": ["string", "null"]},
+#         "task_id": {"type": "string"},
+#         "title": {"type": "string"},
+#         "area": {"type": "string"},
+#         "actionable_steps": {"type": "array", "items": {"type": "string"}},
+#         "acceptance_criteria": {"type": "array", "items": {"type": "string"}},
+#         "assigned_to": {"type": ["string", "null"]},
+#         "epic": {"type": "string"}
 #       }
 #     }
 #   }

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -58,3 +58,28 @@ def test_save_tasks_omit_null_command(tmp_path):
     mem.save_tasks(tasks, tasks_file)
     data = yaml.safe_load(tasks_file.read_text())
     assert "command" not in data[0]
+
+
+def test_task_round_trip_with_optional_fields(tmp_path):
+    tasks = [
+        Task(
+            id=1,
+            task_id="T-1",
+            title="Extended",
+            description="test optional",
+            component="core",
+            dependencies=[],
+            priority=1,
+            status="pending",
+            area="core",
+            actionable_steps=["a", "b"],
+            acceptance_criteria=["c"],
+            assigned_to="dev",
+            epic="E1",
+        )
+    ]
+    tasks_file = tmp_path / "tasks.yml"
+    mem = Memory(tmp_path / "state.json")
+    mem.save_tasks(tasks, tasks_file)
+    loaded = mem.load_tasks(tasks_file)
+    assert loaded == tasks


### PR DESCRIPTION
## Summary
- extend `Task` dataclass with optional metadata fields
- expand task schema in `Memory` and in `tasks.yml`
- ensure tasks round-trip with new fields via tests

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686a5bbddd14832ab6aadc014a8b53df