### PR TITLE
Add Prometheus metrics server to Node service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+services:
+  broker:
+    build:
+      context: .
+      dockerfile: broker/Dockerfile
+    ports:
+      - "8000:8000"
+  worker:
+    build:
+      context: .
+      dockerfile: worker/Dockerfile
+  io-service:
+    build:
+      context: .
+      dockerfile: services/node/Dockerfile
+    ports:
+      - "50051:50051"
+      - "9100:9100"

--- a/services/node/Dockerfile
+++ b/services/node/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install --omit=dev
+COPY . .
+EXPOSE 50051
+EXPOSE 9100
+CMD ["node", "io_server.js"]

--- a/services/node/io_server.js
+++ b/services/node/io_server.js
@@ -1,5 +1,7 @@
 const grpc = require('@grpc/grpc-js');
 const protoLoader = require('@grpc/proto-loader');
+const client = require('prom-client');
+const http = require('http');
 const path = require('path');
 
 const packageDef = protoLoader.loadSync(path.join(__dirname, '../../proto/io_service.proto'));
@@ -9,14 +11,33 @@ function ping(call, callback) {
   callback(null, { message: 'pong:' + call.request.message });
 }
 
+function startMetricsServer(port) {
+  client.collectDefaultMetrics();
+  http
+    .createServer(async (req, res) => {
+      if (req.url === '/metrics') {
+        res.setHeader('Content-Type', client.register.contentType);
+        res.end(await client.register.metrics());
+      } else {
+        res.statusCode = 404;
+        res.end();
+      }
+    })
+    .listen(port, () => {
+      console.log(`Metrics server running on ${port}`);
+    });
+}
+
 function main() {
   const server = new grpc.Server();
   server.addService(proto.IOService.service, { Ping: ping });
   const port = process.env.PORT || '50051';
+  const metricsPort = process.env.METRICS_PORT || '9100';
   server.bindAsync('0.0.0.0:' + port, grpc.ServerCredentials.createInsecure(), () => {
     server.start();
     console.log(`IOService running on ${port}`);
   });
+  startMetricsServer(metricsPort);
 }
 
 if (require.main === module) {

--- a/services/node/package-lock.json
+++ b/services/node/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "@grpc/grpc-js": "^1.9.9",
-        "@grpc/proto-loader": "^0.7.6"
+        "@grpc/proto-loader": "^0.7.6",
+        "prom-client": "^15.1.3"
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -51,6 +52,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
+      }
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -150,6 +160,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/bintrees": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
+      "integrity": "sha512-VOMgTMwjAaUG580SXn3LacVgjurrbMme7ZZNYGSSV7mmtY6QQRh0Eg3pwIcntQ77DErK1L0NxkbetjcoXzVwKw==",
+      "license": "MIT"
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -227,6 +243,19 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/prom-client": {
+      "version": "15.1.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-15.1.3.tgz",
+      "integrity": "sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.4.0",
+        "tdigest": "^0.1.1"
+      },
+      "engines": {
+        "node": "^16 || ^18 || >=20"
+      }
+    },
     "node_modules/protobufjs": {
       "version": "7.5.3",
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.3.tgz",
@@ -284,6 +313,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tdigest": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.2.tgz",
+      "integrity": "sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==",
+      "license": "MIT",
+      "dependencies": {
+        "bintrees": "1.0.2"
       }
     },
     "node_modules/undici-types": {

--- a/services/node/package.json
+++ b/services/node/package.json
@@ -4,6 +4,7 @@
   "main": "io_server.js",
   "dependencies": {
     "@grpc/grpc-js": "^1.9.9",
-    "@grpc/proto-loader": "^0.7.6"
+    "@grpc/proto-loader": "^0.7.6",
+    "prom-client": "^15.1.3"
   }
 }

--- a/tasks.yml
+++ b/tasks.yml
@@ -1333,6 +1333,7 @@
   acceptance_criteria:
     - Full workflow test passes with broker, worker, and Node service running
     - Failure cases are logged and handled gracefully
+  priority: 2
   status: pending
   assigned_to: null
   epic: Reliability
@@ -1349,6 +1350,7 @@
   acceptance_criteria:
     - "`python -m ai_swa.orchestrator --help` shows CLI options"
     - Start/stop commands function as expected in tests
+  priority: 2
   status: pending
   assigned_to: null
   epic: Usability
@@ -1365,6 +1367,7 @@
   acceptance_criteria:
     - "`/metrics` endpoint available on broker and worker"
     - Metrics include task throughput and duration
+  priority: 2
   status: pending
   assigned_to: null
   epic: Observability Improvements
@@ -1382,6 +1385,7 @@
   acceptance_criteria:
     - Loading tasks fails with clear error when schema violations occur
     - Extended fields round-trip without loss
+  priority: 2
   status: pending
   assigned_to: null
   epic: Schema Evolution
@@ -1398,6 +1402,7 @@
   acceptance_criteria:
     - "`docker-compose up` starts all services and tests can run against them"
     - README contains updated instructions
+  priority: 2
   status: pending
   assigned_to: null
   epic: Developer Experience

--- a/tests/test_io_service.py
+++ b/tests/test_io_service.py
@@ -1,7 +1,7 @@
 import subprocess
 import time
-import subprocess
 from pathlib import Path
+import requests
 
 import pytest
 
@@ -11,10 +11,15 @@ from core.io_client import ping
 @pytest.fixture(scope="module")
 def node_server():
     service_dir = Path("services/node")
-    if not (service_dir / "node_modules").exists():
+    if not (service_dir / "node_modules" / "prom-client").exists():
         subprocess.run(["npm", "install"], cwd=service_dir, check=True)
     proc = subprocess.Popen(["node", str(service_dir / "io_server.js")])
-    time.sleep(1)
+    for _ in range(10):
+        try:
+            requests.get("http://localhost:9100/metrics", timeout=1)
+            break
+        except Exception:
+            time.sleep(0.5)
     yield
     proc.terminate()
     proc.wait()
@@ -22,3 +27,9 @@ def node_server():
 
 def test_ping(node_server):
     assert ping("hello") == "pong:hello"
+
+
+def test_metrics_endpoint(node_server):
+    response = requests.get("http://localhost:9100/metrics")
+    assert response.status_code == 200
+    assert "process_cpu_user_seconds_total" in response.text


### PR DESCRIPTION
## Summary
- expose `/metrics` using `prom-client` in the Node gRPC service
- add Dockerfile for Node service and expose ports in docker-compose
- ensure tasks.yml schema passes by adding missing priorities
- test that `/metrics` endpoint returns Prometheus text

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686a6914d96c832abd1b2e8198d1a183