### PR TITLE
Add orchestrator start/stop CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,21 @@ Planner decides what to build next. The Executor writes files and configures CI/
    ```bash
    python3 run_bootstrap.py
    ```
-4. **Explore the Blueprint** – Open `ARCHITECTURE.md` to see components and dependency rationales.
-5. **Watch It Evolve** – Each execution may introduce new tasks or propose refactors. Review and merge the generated commit.
+4. **Start the Orchestrator**
+   ```bash
+   python -m core.cli start
+   # Later stop it
+   python -m core.cli stop
+   ```
+5. **Explore the Blueprint** – Open `ARCHITECTURE.md` to see components and dependency rationales.
+6. **Watch It Evolve** – Each execution may introduce new tasks or propose refactors. Review and merge the generated commit.
+
+### CLI Usage
+
+```
+python -m core.cli start --memory state.json
+python -m core.cli stop
+```
 
 ---
 

--- a/core/cli.py
+++ b/core/cli.py
@@ -3,6 +3,9 @@
 import argparse
 from pathlib import Path
 import sys
+import os
+import signal
+import subprocess
 
 from .orchestrator import Orchestrator
 from .memory import Memory
@@ -22,6 +25,34 @@ def build_parser() -> argparse.ArgumentParser:
         default="state.json",
         help="Path to persistent state file",
     )
+
+    subparsers = parser.add_subparsers(dest="command")
+    run = subparsers.add_parser("run", help="Run orchestrator in foreground")
+    run.add_argument(
+        "--memory",
+        default="state.json",
+        help="Path to persistent state file",
+    )
+
+    start = subparsers.add_parser("start", help="Start orchestrator in background")
+    start.add_argument(
+        "--pid-file",
+        default="orchestrator.pid",
+        help="File to store orchestrator PID",
+    )
+    start.add_argument(
+        "--memory",
+        default="state.json",
+        help="Path to persistent state file",
+    )
+
+    stop = subparsers.add_parser("stop", help="Stop orchestrator started with start")
+    stop.add_argument(
+        "--pid-file",
+        default="orchestrator.pid",
+        help="File containing orchestrator PID",
+    )
+
     return parser
 
 
@@ -29,10 +60,33 @@ def main(argv=None):
     """Run the orchestrator using arguments from ``argv``."""
     parser = build_parser()
     args = parser.parse_args(argv)
+    if args.command is None:
+        args.command = "run"
 
     configure_logging()
 
     setup_telemetry()
+
+    if args.command == "start":
+        cmd = [sys.executable, "-m", "core.cli", "run", "--memory", args.memory]
+        proc = subprocess.Popen(cmd)
+        Path(args.pid_file).write_text(str(proc.pid))
+        print(f"Orchestrator started with PID {proc.pid}")
+        return 0
+
+    if args.command == "stop":
+        pid_path = Path(args.pid_file)
+        if not pid_path.exists():
+            print("PID file not found", file=sys.stderr)
+            return 1
+        pid = int(pid_path.read_text())
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            print("Process not running")
+        pid_path.unlink()
+        print("Orchestrator stopped")
+        return 0
 
     memory = Memory(Path(args.memory))
     try:

--- a/tasks.yml
+++ b/tasks.yml
@@ -1351,7 +1351,7 @@
     - "`python -m ai_swa.orchestrator --help` shows CLI options"
     - Start/stop commands function as expected in tests
   priority: 2
-  status: pending
+  status: done
   assigned_to: null
   epic: Usability
 - id: 125

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -61,3 +61,67 @@ def test_cli_unwritable_memory(tmp_path):
         check=False,
     )
     assert result.returncode != 0
+
+
+def test_cli_start_stop(tmp_path):
+    pid_file = tmp_path / "orch.pid"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    start = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "core.cli",
+            "start",
+            "--pid-file",
+            str(pid_file),
+            "--memory",
+            str(tmp_path / "state.json"),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert start.returncode == 0
+    assert pid_file.exists()
+
+    stop = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "core.cli",
+            "stop",
+            "--pid-file",
+            str(pid_file),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert stop.returncode == 0
+    assert not pid_file.exists()
+
+
+def test_cli_stop_missing_pid(tmp_path):
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "core.cli",
+            "stop",
+            "--pid-file",
+            str(tmp_path / "none.pid"),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
## Summary
- add start/stop commands to CLI with PID management
- document CLI usage in README
- test start/stop behaviour and mark ORCH-CLI task done

## Testing
- `pytest tests/test_cli.py -q`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionError to localhost:9100)*

------
https://chatgpt.com/codex/tasks/task_e_686a6c3b49b4832a94e5b5d94235be14