### PR TITLE
Allow metadata in tasks schema

### DIFF
--- a/core/memory.py
+++ b/core/memory.py
@@ -33,6 +33,7 @@ TASK_SCHEMA = {
             "acceptance_criteria": {"type": "array", "items": {"type": "string"}},
             "assigned_to": {"type": ["string", "null"]},
             "epic": {"type": "string"},
+            "metadata": {"type": "object"},
         },
     },
 }

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -83,3 +83,47 @@ def test_task_round_trip_with_optional_fields(tmp_path):
     mem.save_tasks(tasks, tasks_file)
     loaded = mem.load_tasks(tasks_file)
     assert loaded == tasks
+
+
+def test_load_tasks_with_metadata(tmp_path):
+    tasks_data = [
+        {
+            "id": 1,
+            "description": "meta",
+            "dependencies": [],
+            "priority": 1,
+            "status": "pending",
+            "metadata": {"foo": "bar"},
+        }
+    ]
+    tasks_file = tmp_path / "tasks.yml"
+    tasks_file.write_text(yaml.safe_dump(tasks_data))
+    mem = Memory(tmp_path / "state.json")
+    tasks = mem.load_tasks(tasks_file)
+    assert tasks == [
+        Task(
+            id=1,
+            description="meta",
+            dependencies=[],
+            priority=1,
+            status="pending",
+        )
+    ]
+
+
+def test_invalid_metadata_fails(tmp_path):
+    tasks_data = [
+        {
+            "id": 1,
+            "description": "bad",
+            "dependencies": [],
+            "priority": 1,
+            "status": "pending",
+            "metadata": "not-a-dict",
+        }
+    ]
+    tasks_file = tmp_path / "tasks.yml"
+    tasks_file.write_text(yaml.safe_dump(tasks_data))
+    mem = Memory(tmp_path / "state.json")
+    with pytest.raises(ValidationError):
+        mem.load_tasks(tasks_file)


### PR DESCRIPTION
## Summary
- permit `metadata` objects in `TASK_SCHEMA`
- validate metadata in `Memory.load_tasks`
- test valid/invalid metadata cases

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686a74b9f8ac832ab2df4ee8018875de