### PR TITLE
feat(orchestrator): expose CLI under ai_swa package

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Planner decides what to build next. The Executor writes files and configures CI/
    ```
 4. **Start the Orchestrator**
    ```bash
-   python -m core.cli start
+   python -m ai_swa.orchestrator start
    # Later stop it
-   python -m core.cli stop
+   python -m ai_swa.orchestrator stop
    ```
 5. **Explore the Blueprint** – Open `ARCHITECTURE.md` to see components and dependency rationales.
 6. **Watch It Evolve** – Each execution may introduce new tasks or propose refactors. Review and merge the generated commit.
@@ -81,8 +81,8 @@ Planner decides what to build next. The Executor writes files and configures CI/
 ### CLI Usage
 
 ```
-python -m core.cli start --memory state.json
-python -m core.cli stop
+python -m ai_swa.orchestrator start --memory state.json
+python -m ai_swa.orchestrator stop
 ```
 
 ---

--- a/ai_swa/orchestrator.py
+++ b/ai_swa/orchestrator.py
@@ -1,0 +1,12 @@
+"""CLI entry point for the AI-SWA orchestrator."""
+from core.cli import build_parser, main as cli_main
+
+__all__ = ["build_parser", "main"]
+
+def main(argv=None):
+    """Run the orchestrator CLI."""
+    return cli_main(argv)
+
+if __name__ == "__main__":  # pragma: no cover
+    import sys
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,7 @@ def test_cli_runs(tmp_path):
     cmd = [
         sys.executable,
         "-m",
-        "core.cli",
+        "ai_swa.orchestrator",
         "--memory",
         str(tmp_path / "state.json"),
     ]
@@ -30,7 +30,7 @@ def test_cli_help(tmp_path):
     env = os.environ.copy()
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     result = subprocess.run(
-        [sys.executable, "-m", "core.cli", "--help"],
+        [sys.executable, "-m", "ai_swa.orchestrator", "--help"],
         cwd=tmp_path,
         capture_output=True,
         text=True,
@@ -50,7 +50,7 @@ def test_cli_unwritable_memory(tmp_path):
         [
             sys.executable,
             "-m",
-            "core.cli",
+            "ai_swa.orchestrator",
             "--memory",
             str(memory_dir),
         ],
@@ -71,7 +71,7 @@ def test_cli_start_stop(tmp_path):
         [
             sys.executable,
             "-m",
-            "core.cli",
+            "ai_swa.orchestrator",
             "start",
             "--pid-file",
             str(pid_file),
@@ -91,7 +91,7 @@ def test_cli_start_stop(tmp_path):
         [
             sys.executable,
             "-m",
-            "core.cli",
+            "ai_swa.orchestrator",
             "stop",
             "--pid-file",
             str(pid_file),
@@ -113,7 +113,7 @@ def test_cli_stop_missing_pid(tmp_path):
         [
             sys.executable,
             "-m",
-            "core.cli",
+            "ai_swa.orchestrator",
             "stop",
             "--pid-file",
             str(tmp_path / "none.pid"),


### PR DESCRIPTION
## Summary
- create a top-level `ai_swa` package
- expose `ai_swa.orchestrator` module that re-exports the existing CLI
- update README to use the new module path
- update tests for the new CLI entry point

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b223f60ac832aa7907b4fda797132