### PR TITLE
Add compose env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ Planner decides what to build next. The Executor writes files and configures CI/
    docker-compose up --build
    ```
    This starts the orchestrator, broker, worker, and Node I/O service containers.
+   Environment variables like `BROKER_URL`, `DB_PATH` and metrics ports are set
+   in the compose file so you can simply run `docker-compose up` on subsequent
+   launches for local development.
 
 ### CLI Usage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,11 @@ services:
     volumes:
       - ./tasks.yml:/app/tasks.yml
       - ./state.json:/app/state.json
+      - ./config.yaml:/app/config.yaml
+    environment:
+      BROKER_URL: http://broker:8000
+      WORKER_METRICS_PORT: "9001"
+      BROKER_METRICS_PORT: "9000"
     depends_on:
       - broker
       - worker
@@ -15,16 +20,35 @@ services:
     build:
       context: .
       dockerfile: broker/Dockerfile
+    environment:
+      DB_PATH: /data/tasks.db
+      BROKER_METRICS_PORT: "9000"
+    volumes:
+      - broker-data:/data
     ports:
       - "8000:8000"
+      - "9000:9000"
   worker:
     build:
       context: .
       dockerfile: worker/Dockerfile
+    environment:
+      BROKER_URL: http://broker:8000
+      WORKER_METRICS_PORT: "9001"
+    depends_on:
+      - broker
+    ports:
+      - "9001:9001"
   io-service:
     build:
       context: .
       dockerfile: services/node/Dockerfile
+    environment:
+      PORT: "50051"
+      METRICS_PORT: "9100"
     ports:
       - "50051:50051"
       - "9100:9100"
+
+volumes:
+  broker-data:

--- a/tasks.yml
+++ b/tasks.yml
@@ -1330,6 +1330,7 @@
     - Verify outputs via REST/gRPC responses
   dependencies:
     - 115
+  priority: 2
   acceptance_criteria:
     - Full workflow test passes with broker, worker, and Node service running
     - Failure cases are logged and handled gracefully
@@ -1346,6 +1347,7 @@
     - Support configuration file path and verbosity flags
     - Write usage documentation and tests
   dependencies: []
+  priority: 2
   acceptance_criteria:
     - "`python -m ai_swa.orchestrator --help` shows CLI options"
     - Start/stop commands function as expected in tests
@@ -1362,6 +1364,7 @@
     - Define metrics for task counts and processing duration
     - Document how to scrape metrics
   dependencies: []
+  priority: 2
   acceptance_criteria:
     - "`/metrics` endpoint available on broker and worker"
     - Metrics include task throughput and duration
@@ -1379,6 +1382,7 @@
     - Add tests for invalid and valid schemas
   dependencies:
     - 121
+  priority: 2
   acceptance_criteria:
     - Loading tasks fails with clear error when schema violations occur
     - Extended fields round-trip without loss
@@ -1395,6 +1399,7 @@
     - Create `docker-compose.yml` orchestrating all services
     - Document usage in README
   dependencies: []
+  priority: 2
   acceptance_criteria:
     - "`docker-compose up` starts all services and tests can run against them"
     - README contains updated instructions


### PR DESCRIPTION
## Summary
- pass BROKER_URL and DB_PATH through docker-compose
- expose metrics ports
- document docker-compose usage in README
- fix tasks schema by adding missing priority fields

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b2dc91550832a9aa37f22905a58b1