### PR TITLE
Update CLI with argparse and add status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,9 @@ Planner decides what to build next. The Executor writes files and configures CI/
    ```
 4. **Start the Orchestrator**
    ```bash
-   python -m ai_swa.orchestrator start
+   python -m ai_swa.orchestrator --config config.yaml start
+   # Check status
+   python -m ai_swa.orchestrator status
    # Later stop it
    python -m ai_swa.orchestrator stop
    ```
@@ -84,7 +86,8 @@ Planner decides what to build next. The Executor writes files and configures CI/
 ### CLI Usage
 
 ```
-python -m ai_swa.orchestrator start --memory state.json
+python -m ai_swa.orchestrator --config config.yaml start
+python -m ai_swa.orchestrator status
 python -m ai_swa.orchestrator stop
 ```
 

--- a/core/cli.py
+++ b/core/cli.py
@@ -1,11 +1,10 @@
-"""Command line interface for AI-SWA orchestration."""
-
 import argparse
-from pathlib import Path
-import sys
+import logging
 import os
 import signal
 import subprocess
+import sys
+from pathlib import Path
 
 from .orchestrator import Orchestrator
 from .memory import Memory
@@ -18,32 +17,27 @@ from .log_utils import configure_logging
 
 
 def build_parser() -> argparse.ArgumentParser:
-    """Create and return the command line parser."""
-    parser = argparse.ArgumentParser(description="AI-SWE orchestration CLI")
+    """Return argument parser for the CLI."""
+    parser = argparse.ArgumentParser(description="AI-SWA orchestration CLI")
     parser.add_argument(
-        "--memory",
-        default="state.json",
-        help="Path to persistent state file",
+        "--config",
+        default="config.yaml",
+        help="Path to configuration file",
     )
-
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity",
+    )
     subparsers = parser.add_subparsers(dest="command")
-    run = subparsers.add_parser("run", help="Run orchestrator in foreground")
-    run.add_argument(
-        "--memory",
-        default="state.json",
-        help="Path to persistent state file",
-    )
 
     start = subparsers.add_parser("start", help="Start orchestrator in background")
     start.add_argument(
         "--pid-file",
         default="orchestrator.pid",
         help="File to store orchestrator PID",
-    )
-    start.add_argument(
-        "--memory",
-        default="state.json",
-        help="Path to persistent state file",
     )
 
     stop = subparsers.add_parser("stop", help="Stop orchestrator started with start")
@@ -53,22 +47,68 @@ def build_parser() -> argparse.ArgumentParser:
         help="File containing orchestrator PID",
     )
 
+    status = subparsers.add_parser("status", help="Show orchestrator status")
+    status.add_argument(
+        "--pid-file",
+        default="orchestrator.pid",
+        help="File containing orchestrator PID",
+    )
+
+    # Internal command used by "start"; not exposed in docs
+    run = subparsers.add_parser("_run")
+    run.add_argument("--config", default="config.yaml")
+    run.add_argument("-v", "--verbose", action="count", default=0)
+
     return parser
 
 
-def main(argv=None):
-    """Run the orchestrator using arguments from ``argv``."""
+def _logging_level(verbosity: int) -> int:
+    return logging.DEBUG if verbosity else logging.INFO
+
+
+def _check_config(path: Path) -> bool:
+    if not path.exists():
+        print(f"Config not found: {path}", file=sys.stderr)
+        return False
+    return True
+
+
+def _run_orchestrator(config: Path, verbosity: int) -> int:
+    if not _check_config(config):
+        return 1
+    configure_logging(level=_logging_level(verbosity))
+    setup_telemetry()
+    memory = Memory(Path("state.json"))
+    try:
+        memory.save(memory.load())
+    except Exception as exc:  # pragma: no cover - unexpected I/O errors
+        print(f"Error accessing memory: {exc}", file=sys.stderr)
+        return 1
+
+    planner = Planner()
+    executor = Executor()
+    reflector = Reflector()
+    auditor = SelfAuditor()
+    orchestrator = Orchestrator(planner, executor, reflector, memory, auditor)
+    print("Orchestrator running")
+    orchestrator.run()
+    return 0
+
+
+def main(argv=None) -> int:
+    """CLI entry point."""
     parser = build_parser()
     args = parser.parse_args(argv)
-    if args.command is None:
-        args.command = "run"
-
-    configure_logging()
-
-    setup_telemetry()
+    if not args.command:
+        parser.print_help()
+        return 1
 
     if args.command == "start":
-        cmd = [sys.executable, "-m", "core.cli", "run", "--memory", args.memory]
+        config = Path(args.config)
+        if not _check_config(config):
+            return 1
+        cmd = [sys.executable, "-m", "ai_swa.orchestrator", "_run", "--config", str(config)]
+        cmd += ["-v"] * args.verbose
         proc = subprocess.Popen(cmd)
         Path(args.pid_file).write_text(str(proc.pid))
         print(f"Orchestrator started with PID {proc.pid}")
@@ -84,25 +124,30 @@ def main(argv=None):
             os.kill(pid, signal.SIGTERM)
         except ProcessLookupError:
             print("Process not running")
-        pid_path.unlink()
+        pid_path.unlink(missing_ok=True)
         print("Orchestrator stopped")
         return 0
 
-    memory = Memory(Path(args.memory))
-    try:
-        memory.save(memory.load())
-    except Exception as exc:  # pragma: no cover - unexpected I/O errors
-        print(f"Error accessing memory: {exc}", file=sys.stderr)
-        return 1
+    if args.command == "status":
+        pid_path = Path(args.pid_file)
+        if not pid_path.exists():
+            print("Not running")
+            return 1
+        pid = int(pid_path.read_text())
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            print("Not running")
+            pid_path.unlink(missing_ok=True)
+            return 1
+        print(f"Orchestrator running with PID {pid}")
+        return 0
 
-    planner = Planner()
-    executor = Executor()
-    reflector = Reflector()
-    auditor = SelfAuditor()
-    orchestrator = Orchestrator(planner, executor, reflector, memory, auditor)
-    print("Orchestrator running")
-    orchestrator.run()
-    return 0
+    if args.command == "_run":
+        return _run_orchestrator(Path(args.config), args.verbose)
+
+    parser.print_help()
+    return 1
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,20 +1,11 @@
+import os
 import subprocess
 import sys
-import os
 from pathlib import Path
 
 
-def test_cli_runs(tmp_path):
-    cmd = [
-        sys.executable,
-        "-m",
-        "ai_swa.orchestrator",
-        "--memory",
-        str(tmp_path / "state.json"),
-    ]
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
-    result = subprocess.run(
+def _run(cmd, tmp_path, env):
+    return subprocess.run(
         cmd,
         cwd=tmp_path,
         capture_output=True,
@@ -22,106 +13,82 @@ def test_cli_runs(tmp_path):
         env=env,
         check=False,
     )
-    assert result.returncode == 0
-    assert "Orchestrator running" in result.stdout
 
 
 def test_cli_help(tmp_path):
     env = os.environ.copy()
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
-    result = subprocess.run(
-        [sys.executable, "-m", "ai_swa.orchestrator", "--help"],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        env=env,
-        check=False,
-    )
+    result = _run([sys.executable, "-m", "ai_swa.orchestrator", "--help"], tmp_path, env)
     assert result.returncode == 0
-    assert "usage" in result.stdout.lower()
+    out = result.stdout.lower()
+    assert "start" in out and "stop" in out and "status" in out
 
 
-def test_cli_unwritable_memory(tmp_path):
-    memory_dir = tmp_path / "memory"
-    memory_dir.mkdir()
-    env = os.environ.copy()
-    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "ai_swa.orchestrator",
-            "--memory",
-            str(memory_dir),
-        ],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        env=env,
-        check=False,
-    )
-    assert result.returncode != 0
-
-
-def test_cli_start_stop(tmp_path):
+def test_cli_start_status_stop(tmp_path):
     pid_file = tmp_path / "orch.pid"
+    config = tmp_path / "config.yaml"
+    config.write_text("test: true")
     env = os.environ.copy()
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
-    start = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "ai_swa.orchestrator",
-            "start",
-            "--pid-file",
-            str(pid_file),
-            "--memory",
-            str(tmp_path / "state.json"),
-        ],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        env=env,
-        check=False,
-    )
+
+    start = _run([
+        sys.executable,
+        "-m",
+        "ai_swa.orchestrator",
+        "--config",
+        str(config),
+        "start",
+        "--pid-file",
+        str(pid_file),
+    ], tmp_path, env)
     assert start.returncode == 0
     assert pid_file.exists()
 
-    stop = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "ai_swa.orchestrator",
-            "stop",
-            "--pid-file",
-            str(pid_file),
-        ],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        env=env,
-        check=False,
-    )
+    status = _run([
+        sys.executable,
+        "-m",
+        "ai_swa.orchestrator",
+        "status",
+        "--pid-file",
+        str(pid_file),
+    ], tmp_path, env)
+    assert status.returncode == 0
+    assert "running" in status.stdout.lower()
+
+    stop = _run([
+        sys.executable,
+        "-m",
+        "ai_swa.orchestrator",
+        "stop",
+        "--pid-file",
+        str(pid_file),
+    ], tmp_path, env)
     assert stop.returncode == 0
     assert not pid_file.exists()
 
+    status2 = _run([
+        sys.executable,
+        "-m",
+        "ai_swa.orchestrator",
+        "status",
+        "--pid-file",
+        str(pid_file),
+    ], tmp_path, env)
+    assert status2.returncode != 0
 
-def test_cli_stop_missing_pid(tmp_path):
+
+def test_cli_start_missing_config(tmp_path):
+    pid_file = tmp_path / "orch.pid"
     env = os.environ.copy()
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "ai_swa.orchestrator",
-            "stop",
-            "--pid-file",
-            str(tmp_path / "none.pid"),
-        ],
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        env=env,
-        check=False,
-    )
+    result = _run([
+        sys.executable,
+        "-m",
+        "ai_swa.orchestrator",
+        "start",
+        "--pid-file",
+        str(pid_file),
+        "--config",
+        str(tmp_path / "missing.yaml"),
+    ], tmp_path, env)
     assert result.returncode != 0


### PR DESCRIPTION
## Summary
- implement new CLI with argparse supporting `start`, `stop` and `status`
- add global `--config` and `-v/--verbose` options
- update usage docs in README
- add tests for new CLI behaviour

## Testing
- `pip install -q -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b2ff969c0832aa2b738794ceef665