### PR TITLE
Add broker and worker metrics tests

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,31 @@
+import requests
+import pytest
+from core.telemetry import setup_telemetry
+
+
+@pytest.fixture
+def start_broker():
+    server, _ = setup_telemetry(service_name="broker", metrics_port=0)
+    try:
+        yield server.server_port
+    finally:
+        server.shutdown()
+
+
+@pytest.fixture
+def start_worker():
+    server, _ = setup_telemetry(service_name="worker", metrics_port=0)
+    try:
+        yield server.server_port
+    finally:
+        server.shutdown()
+
+
+def test_broker_metrics(start_broker):
+    resp = requests.get(f"http://localhost:{start_broker}/metrics")
+    assert resp.status_code == 200
+
+
+def test_worker_metrics(start_worker):
+    resp = requests.get(f"http://localhost:{start_worker}/metrics")
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- start broker and worker metric servers on dynamic ports
- verify `/metrics` returns 200 for each component

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b31b08f6c832a85708f5c83e8c692