### PR TITLE
Update README with config info

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,38 @@ python -m ai_swa.orchestrator status
 python -m ai_swa.orchestrator stop
 ```
 
+## Configuration
+
+AI-SWA loads settings from `config.yaml` by default. Set `CONFIG_FILE` to use a
+different file. Environment variables listed below override values from the
+configuration file:
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `DB_PATH` | Path to the broker SQLite database | `tasks.db` |
+| `BROKER_URL` | Broker service URL used by the worker and orchestrator | `http://broker:8000` |
+| `BROKER_METRICS_PORT` | Port exposing broker Prometheus metrics | `9000` |
+| `WORKER_METRICS_PORT` | Port exposing worker Prometheus metrics | `9001` |
+| `METRICS_PORT` | Set both broker and worker metrics ports at once | *(unset)* |
+| `API_KEY` | Shared API key required for API access | *(unset)* |
+| `API_TOKENS` | Comma separated tokens mapping to `username:role` | *(unset)* |
+| `PLUGIN_SIGNING_KEY` | HMAC key used to verify plugin manifests | *(unset)* |
+
+### Example usage
+
+Run the services directly with overrides:
+
+```bash
+DB_PATH=/tmp/tasks.db BROKER_URL=http://localhost:8000 \
+    python -m ai_swa.orchestrator --config config.yaml start
+```
+
+When using Docker Compose these variables can be supplied on the command line:
+
+```bash
+BROKER_URL=http://localhost:8000 DB_PATH=./tasks.db docker-compose up
+```
+
 ---
 
 ## 🎯 Roadmap


### PR DESCRIPTION
## Summary
- document supported environment variables
- add usage examples for overriding defaults

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b4fb86f2c832ab46864e7f0106400