### PR TITLE
feat(core): configurable node host and port

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,9 @@ broker:
 worker:
   broker_url: http://broker:8000
   metrics_port: 9001
+node:
+  host: localhost
+  port: 50051
 security:
   api_key: null
   api_tokens: null

--- a/core/config.py
+++ b/core/config.py
@@ -9,6 +9,7 @@ import yaml
 DEFAULT_CONFIG = {
     "broker": {"db_path": "tasks.db", "metrics_port": 9000},
     "worker": {"broker_url": "http://broker:8000", "metrics_port": 9001},
+    "node": {"host": "localhost", "port": 50051},
     "security": {"api_key": None, "api_tokens": None, "plugin_signing_key": None},
 }
 
@@ -25,6 +26,7 @@ def load_config(path: str | Path | None = None) -> dict:
     cfg = {
         "broker": {**DEFAULT_CONFIG["broker"], **data.get("broker", {})},
         "worker": {**DEFAULT_CONFIG["worker"], **data.get("worker", {})},
+        "node": {**DEFAULT_CONFIG["node"], **data.get("node", {})},
         "security": {**DEFAULT_CONFIG["security"], **data.get("security", {})},
     }
 
@@ -36,6 +38,10 @@ def load_config(path: str | Path | None = None) -> dict:
         cfg["broker"]["metrics_port"] = int(os.environ["BROKER_METRICS_PORT"])
     if "WORKER_METRICS_PORT" in os.environ:
         cfg["worker"]["metrics_port"] = int(os.environ["WORKER_METRICS_PORT"])
+    if "NODE_HOST" in os.environ:
+        cfg["node"]["host"] = os.environ["NODE_HOST"]
+    if "NODE_PORT" in os.environ:
+        cfg["node"]["port"] = int(os.environ["NODE_PORT"])
     if "METRICS_PORT" in os.environ:
         port = int(os.environ["METRICS_PORT"])
         cfg["broker"]["metrics_port"] = port

--- a/core/io_client.py
+++ b/core/io_client.py
@@ -1,10 +1,14 @@
 import grpc
 from . import io_service_pb2, io_service_pb2_grpc
+from .config import load_config
 
 
-def ping(message: str, host: str = "localhost", port: int = 50051) -> str:
+def ping(message: str, host: str | None = None, port: int | None = None) -> str:
     """Send a ping request to the Node IOService."""
-    channel = grpc.insecure_channel(f"{host}:{port}")
+    cfg = load_config()
+    host = host or cfg.get("node", {}).get("host", "localhost")
+    port = port or cfg.get("node", {}).get("port", 50051)
+    channel = grpc.insecure_channel(f"{host}:{int(port)}")
     stub = io_service_pb2_grpc.IOServiceStub(channel)
     response = stub.Ping(io_service_pb2.PingRequest(message=message))
     return response.message

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,23 @@
+import os
+from core.config import load_config
+
+
+def test_load_node_config(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("""\nnode:\n  host: testhost\n  port: 1234\n""")
+    monkeypatch.setenv("CONFIG_FILE", str(cfg_file))
+    cfg = load_config()
+    assert cfg["node"]["host"] == "testhost"
+    assert cfg["node"]["port"] == 1234
+
+
+def test_node_env_override(tmp_path, monkeypatch):
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("node:\n  host: filehost\n  port: 1111\n")
+    monkeypatch.setenv("CONFIG_FILE", str(cfg_file))
+    monkeypatch.setenv("NODE_HOST", "envhost")
+    monkeypatch.setenv("NODE_PORT", "2222")
+    cfg = load_config()
+    assert cfg["node"]["host"] == "envhost"
+    assert cfg["node"]["port"] == 2222
+


### PR DESCRIPTION
## Summary
- configure node host/port in `config.yaml`
- read `NODE_HOST` and `NODE_PORT` overrides in config loader
- update IO client to use config values
- test configuration loading logic

## Testing
- `pytest --maxfail=1 --disable-warnings -q`
- `pytest tests/test_config.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686b616fa268832a898af27a40688d40