### PR TITLE
Handle missing dependencies in planner

### DIFF
--- a/core/planner.py
+++ b/core/planner.py
@@ -1,5 +1,8 @@
 from typing import List, Optional
 from .task import Task
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class Planner:
@@ -48,10 +51,22 @@ class Planner:
             dependencies_met = True
             for dep_id in task.dependencies:
                 # Find the dependent task in the original list
-                dependent_task = next((t for t in tasks if hasattr(t, 'id') and t.id == dep_id), None)
+                dependent_task = next(
+                    (t for t in tasks if hasattr(t, 'id') and t.id == dep_id),
+                    None,
+                )
 
-                # If a dependency is not found or not "done", it's not met
-                if not dependent_task or not hasattr(dependent_task, 'status') or dependent_task.status != "done":
+                if not dependent_task:
+                    logger.warning(
+                        "Task %s skipped: dependency %s not found",
+                        getattr(task, "id", "<unknown>"),
+                        dep_id,
+                    )
+                    dependencies_met = False
+                    break
+
+                # If dependency task exists but is not "done", it's not met
+                if not hasattr(dependent_task, 'status') or dependent_task.status != "done":
                     dependencies_met = False
                     break
 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -178,6 +178,12 @@ class TestPlanner(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.planner.plan(tasks)
 
+    def test_warning_emitted_for_missing_dependency(self):
+        task = self._create_task("main", 5, "pending", ["missing"])
+        with self.assertLogs("core.planner", level="WARNING") as cm:
+            self.planner.plan([task])
+        self.assertTrue(any("missing" in msg for msg in cm.output))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- log a warning and skip a task if its dependency id does not exist
- test that the warning is emitted when a dependency is missing

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b62b22d4c832a86f707975ab5fbec