### PR TITLE
Add review task for worker queue

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -886,3 +886,19 @@
   status: pending
   assigned_to: null
   epic: Reflector Outer Loop
+
+- id: 138
+  description: Review broker queue endpoint and worker concurrency
+  dependencies:
+  - 133
+  priority: 3
+  status: pending
+  area: review
+  actionable_steps:
+  - Check broker exposes queue-based endpoint such as GET /tasks/next
+  - Run multiple workers concurrently and ensure tasks are not duplicated
+  acceptance_criteria:
+  - Broker delivers one task at a time via queue endpoint
+  - No duplicate processing occurs with multiple workers
+  assigned_to: null
+  epic: Reliability


### PR DESCRIPTION
## Summary
- add a new review task linked to task 133
- confirm that queue endpoint is still missing and worker fetches all tasks

## Testing
- `pip install -q -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b63d1a6fc832ab2975309724dfa09