### PR TITLE
Add CI audit for SEC-001

### DIFF
--- a/docs/reviews/task_135_ci_audit.md
+++ b/docs/reviews/task_135_ci_audit.md
@@ -1,0 +1,43 @@
+# CI Audit for Task 135: Automated Plugin Certification Pipeline
+
+Task 135 (SEC-001) aims to integrate automated security checks and signing into the CI pipeline. We inspected `.github/workflows/ci.yml` after the task implementation.
+
+## Findings
+
+Current CI steps include dependency installation, Docker builds, linting with `pylint`, and running unit tests:
+
+```yaml
+      build:
+        runs-on: ubuntu-latest
+        steps:
+          - uses: actions/checkout@v3
+          - name: Set up Python
+            uses: actions/setup-python@v5
+            with:
+              python-version: '3.12'
+          - name: Install dependencies
+            run: |
+              python -m pip install --upgrade pip
+              pip install -r requirements.txt
+          - name: Build Docker images
+            run: docker compose -f docker-compose.yml build
+          - name: Install pylint
+            run: pip install pylint==3.3.7
+          - name: Run pylint
+            run: |
+              pylint --exit-zero core tests
+          - name: Run tests
+            run: |
+              pytest --maxfail=1 --disable-warnings -q
+```
+
+However, there are **no stages** for:
+
+- Software Composition Analysis (SCA)
+- Static Application Security Testing (SAST)
+- Sandboxed dynamic testing of plugins
+- Automatic signing of vetted plugins
+
+## Conclusion
+
+The pipeline does not yet implement the full certification process. Implementing SCA, SAST, sandbox tests, and signing stages is still outstanding.

--- a/tasks.yml
+++ b/tasks.yml
@@ -916,3 +916,17 @@
   - Findings documented in docs/research/RL_vs_WSJF_Test_Report.md
   assigned_to: null
   epic: Vision Engine RL
+- id: 140
+  description: Review CI for SEC-001 plugin certification pipeline
+  dependencies:
+  - 135
+  priority: 3
+  status: pending
+  area: review
+  actionable_steps:
+  - Audit CI logs to verify SCA, SAST, sandbox tests, and signing steps
+  - Document findings in docs/reviews/task_135_ci_audit.md
+  acceptance_criteria:
+  - Report identifies any missing or failing certification stages
+  assigned_to: null
+  epic: Ecosystem


### PR DESCRIPTION
## Summary
- record CI review for SEC-001 plugin certification pipeline
- add follow-up review task to verify SCA, SAST, sandbox tests, and signing

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b6790b748832a9618960d062824b4