### PR TITLE
Implement basic Ethical Sentinel enforcement

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,7 +57,7 @@ def main(argv=None):
     parser = build_parser()
     args = parser.parse_args(argv)
     memory = Memory(Path(args.memory))
-    orchestrator = Orchestrator(None, None, None, memory)
+    orchestrator = Orchestrator(None, None, None, memory, None)
     orchestrator.run()
 ```
 

--- a/core/sentinel.py
+++ b/core/sentinel.py
@@ -1,0 +1,26 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class EthicalSentinel:
+    """Simple policy checker loading blocked actions from a JSON file."""
+
+    policy_path: Path
+    blocked_actions: set[str] | None = None
+
+    def load_policies(self) -> None:
+        """Load blocked actions from the policy file."""
+        if not self.policy_path.exists():
+            self.blocked_actions = set()
+            return
+        with self.policy_path.open() as f:
+            data = json.load(f)
+        self.blocked_actions = set(data.get("blocked_actions", []))
+
+    def allows(self, action: str) -> bool:
+        """Return True if ``action`` is permitted."""
+        if self.blocked_actions is None:
+            self.load_policies()
+        return action not in self.blocked_actions

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,8 @@
+# Governance
+
+The Ethical Sentinel component enforces policy compliance for agent actions. When enabled, the orchestrator
+loads a JSON policy file specifying blocked action IDs. If a task's ID matches an entry in `blocked_actions`,
+the Sentinel prevents execution and logs a message.
+
+This mechanism ensures that high‑risk tasks can be centrally disabled without modifying code. Policies are
+loaded lazily when first evaluated so updates take effect on the next run.

--- a/docs/reviews/task_136_sentinel.md
+++ b/docs/reviews/task_136_sentinel.md
@@ -1,0 +1,7 @@
+# Task 136 Sentinel Integration Review
+
+Verify that the Ethical Sentinel loads policy files and blocks tasks that match
+listed `blocked_actions`.
+
+- Run the orchestrator with a policy that lists a known task ID.
+- Ensure the task is skipped and a log entry indicates the block.

--- a/tasks.yml
+++ b/tasks.yml
@@ -930,3 +930,17 @@
   - Report identifies any missing or failing certification stages
   assigned_to: null
   epic: Ecosystem
+- id: 141
+  description: Review Ethical Sentinel policy enforcement for task 136
+  dependencies:
+  - 136
+  priority: 3
+  status: pending
+  area: review
+  actionable_steps:
+  - Run orchestrator with a policy blocking a sample task
+  - Confirm task does not execute and is logged as blocked
+  acceptance_criteria:
+  - docs/reviews/task_136_sentinel.md summarizes results
+  assigned_to: null
+  epic: Governance

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,0 +1,44 @@
+import json
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+from core.sentinel import EthicalSentinel
+from core.orchestrator import Orchestrator
+from core.task import Task
+from core.planner import Planner
+from core.executor import Executor
+from core.reflector import Reflector
+from core.memory import Memory
+from core.self_auditor import SelfAuditor
+
+
+def test_policy_loading_and_blocking(tmp_path: Path):
+    policy = tmp_path / "policy.json"
+    policy.write_text(json.dumps({"blocked_actions": ["block"]}))
+    sentinel = EthicalSentinel(policy)
+
+    task = Task(id="block", description="", component="core", dependencies=[], priority=1, status="pending")
+
+    memory = MagicMock(spec=Memory)
+    memory.load_tasks.return_value = [task]
+    memory.save_tasks.return_value = None
+
+    planner = MagicMock(spec=Planner)
+    planner.plan.side_effect = [task, None]
+
+    reflector = MagicMock(spec=Reflector)
+    reflector.run_cycle.return_value = [task]
+
+    auditor = MagicMock(spec=SelfAuditor)
+    auditor.audit.return_value = []
+
+    executor = MagicMock(spec=Executor)
+    orch = Orchestrator(planner, executor, reflector, memory, auditor, sentinel=sentinel)
+
+    with patch('builtins.print'):
+        orch.run("tasks.yml")
+
+    assert sentinel.blocked_actions == {"block"}
+    # Executor should not be called because sentinel blocks the action
+    # Executor from core is used; we patch execute method to observe calls
+
+    executor.execute.assert_not_called()


### PR DESCRIPTION
## Summary
- implement `EthicalSentinel` for loading policy files
- integrate sentinel with `Orchestrator`
- document sentinel behaviour in `docs/governance.md`
- add review notes for task 136
- append new review task 141 linked to task 136
- cover sentinel enforcement via new unit test

## Testing
- `pip install -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b69065ba4832ab2fdaefb07503d4e