### PR TITLE
Add doc for periodic task archiving

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,8 @@ To introduce a new agent to the system, the following process must be followed:
 
 - Follow the Iterative Development Protocol described in `README.md`.
 - Keep `tasks.yml` up to date, marking tasks as `done` once implemented.
+- Periodically run `python scripts/archive_tasks.py` to move completed tasks to
+  `tasks_archive.yml`.
 
 ### Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -390,4 +390,6 @@ Run the helper script to move finished tasks out of the main list:
 python scripts/archive_tasks.py --tasks tasks.yml --archive tasks_archive.yml
 ```
 This updates `tasks.yml` and appends archived items to `tasks_archive.yml`.
+Run this script on a regular basis (for example weekly) to keep the task list
+concise.
 

--- a/scripts/archive_tasks.py
+++ b/scripts/archive_tasks.py
@@ -1,3 +1,11 @@
+
+"""Move completed tasks from ``tasks.yml`` to ``tasks_archive.yml``.
+
+This helper preserves any comment header and appends archived tasks to the
+archive file.  It is intended to keep ``tasks.yml`` concise.  Run periodically
+or whenever tasks accumulate.
+"""
+
 import argparse
 from pathlib import Path
 import yaml


### PR DESCRIPTION
## Summary
- document periodic use of `archive_tasks.py` in README and AGENTS
- add module docstring explaining script usage

## Testing
- `pip install -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b7daaecf0832a98454bd6c1f01a07