### PR TITLE
Add RL training persistence

### DIFF
--- a/docs/reviews/task_134_rl_audit.md
+++ b/docs/reviews/task_134_rl_audit.md
@@ -1,0 +1,12 @@
+# Task 134 RL Agent Integration Audit
+
+Task 134 introduced an RL-driven refinement layer for the Vision Engine. We reviewed the implementation to ensure shadow logging, training data persistence and authority updates all behave correctly.
+
+## Findings
+
+- `RLAgent.record_shadow_result` writes JSON lines to the specified history path. Unit tests confirm a file is created when running in shadow mode.
+- `train()` now accepts metrics and appends them to in-memory `training_data`. When `training_path` is provided, metrics are also persisted to disk for offline analysis.
+- `update_authority()` increases authority only when performance gains exceed a threshold; tests validate this behaviour.
+
+Overall the RL agent integrates cleanly with `VisionEngine` and persists both history and training metrics as intended.
+

--- a/tasks.yml
+++ b/tasks.yml
@@ -818,7 +818,7 @@
   - The RL agent can be trained on historical data from the observability pipeline.
   - In shadow mode, the agent's suggested rankings are logged for analysis.
   priority: 1
-  status: pending
+  status: done
   assigned_to: null
   epic: Vision Engine RL
 - id: 135

--- a/tests/test_rl_training.py
+++ b/tests/test_rl_training.py
@@ -1,3 +1,5 @@
+import json
+
 from core.observability import MetricsProvider
 from vision.vision_engine import RLAgent
 from vision.training import RLTrainer
@@ -11,3 +13,16 @@ def test_rl_trainer_runs(tmp_path):
     trainer = RLTrainer(agent=agent, metrics_provider=provider)
     trainer.run()
     assert agent.training_data == [{"coverage": 85}]
+
+
+def test_rl_training_persists_data(tmp_path):
+    metrics_file = tmp_path / "metrics.json"
+    metrics_file.write_text('{"coverage": 99}')
+    train_file = tmp_path / "train.log"
+    provider = MetricsProvider(metrics_file)
+    agent = RLAgent(training_path=train_file)
+    trainer = RLTrainer(agent=agent, metrics_provider=provider)
+    trainer.run()
+    assert train_file.exists()
+    data = train_file.read_text().strip()
+    assert json.loads(data) == {"coverage": 99}

--- a/vision/vision_engine.py
+++ b/vision/vision_engine.py
@@ -57,10 +57,15 @@ class VisionEngine:
 class RLAgent:
     """Minimal stub of an RL agent for prioritization."""
 
-    def __init__(self, history_path: Optional[Path] = None) -> None:
+    def __init__(
+        self,
+        history_path: Optional[Path] = None,
+        training_path: Optional[Path] = None,
+    ) -> None:
         self.history: List[Dict[str, List[int]]] = []
         self.training_data: List[Dict[str, float]] = []
         self.history_path = Path(history_path) if history_path else None
+        self.training_path = Path(training_path) if training_path else None
         self.authority: float = 0.0
 
     def suggest(self, tasks: List[Task]) -> List[Task]:
@@ -81,6 +86,9 @@ class RLAgent:
     def train(self, metrics: Dict[str, float]) -> None:
         """Collect ``metrics`` for offline training."""
         self.training_data.append(metrics)
+        if self.training_path:
+            with self.training_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(metrics) + "\n")
 
     def update_authority(self, performance_gain: float, threshold: float = 0.05) -> None:
         """Increase authority when ``performance_gain`` exceeds ``threshold``."""


### PR DESCRIPTION
## Summary
- persist RL training metrics to disk when provided a path
- validate the new persistence behavior in tests
- mark RL agent integration task as complete
- document audit findings of task 134

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b8577c310832a8b85fa0c68823127