### PR TITLE
Add logging for sentinel policy blocks

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -62,9 +62,11 @@ class Orchestrator:
     # ------------------------------------------------------------------
     def _execute_task(self, task: Task, tasks: List[Task], tasks_file: str) -> None:
         if self.sentinel and not self.sentinel.allows(getattr(task, "id", "")):
-            print(
+            message = (
                 f"Orchestrator: Task '{getattr(task, 'id', 'N/A')}' blocked by Ethical Sentinel."
             )
+            print(message)
+            self.logger.info(message)
             return
         if hasattr(task, "status"):
             task.status = "in_progress"

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -34,11 +34,14 @@ def test_policy_loading_and_blocking(tmp_path: Path):
     executor = MagicMock(spec=Executor)
     orch = Orchestrator(planner, executor, reflector, memory, auditor, sentinel=sentinel)
 
-    with patch('builtins.print'):
+    orch.logger = MagicMock()
+    message = "Orchestrator: Task 'block' blocked by Ethical Sentinel."
+
+    with patch('builtins.print') as mock_print:
         orch.run("tasks.yml")
 
     assert sentinel.blocked_actions == {"block"}
+    mock_print.assert_any_call(message)
+    orch.logger.info.assert_called_with(message)
     # Executor should not be called because sentinel blocks the action
-    # Executor from core is used; we patch execute method to observe calls
-
     executor.execute.assert_not_called()


### PR DESCRIPTION
## Summary
- log Ethical Sentinel policy violations via `logger.info`
- verify blocked tasks trigger log messages and skip execution

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686b897cd560832aa2f4418d63023fc6