### PR TITLE
Add plugin manifest schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ configuration file:
 | `API_TOKENS` | Comma separated tokens mapping to `username:role` | *(unset)* |
 | `PLUGIN_SIGNING_KEY` | HMAC key used to verify plugin manifests | *(unset)* |
 
+### Plugin Manifests
+
+Each plugin contains a `manifest.json` file validated against
+`plugins/manifest_schema.json`. The manifest must define `id`, `name`,
+`version`, and a list of `permissions`. A `signature` field is optional
+and is verified when `PLUGIN_SIGNING_KEY` is set.
+
 ## 📈 Observability
 
 All services expose Prometheus-compatible metrics. The Node I/O service uses

--- a/core/plugins.py
+++ b/core/plugins.py
@@ -7,8 +7,14 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import List
 
+from jsonschema import validate
+
 from .security import validate_plugin_permissions, verify_plugin_signature
 from .config import load_config
+
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / "plugins" / "manifest_schema.json"
+with open(SCHEMA_PATH, "r") as f:
+    MANIFEST_SCHEMA = json.load(f)
 
 
 @dataclass
@@ -31,6 +37,7 @@ def load_manifest(path: Path) -> PluginManifest:
     """Load and validate a plugin manifest from ``path``."""
     with open(path, "r") as f:
         data = json.load(f)
+    validate(instance=data, schema=MANIFEST_SCHEMA)
     manifest = PluginManifest(**data)
     validate_plugin_permissions(manifest.permissions)
     if manifest.signature:

--- a/plugins/manifest_schema.json
+++ b/plugins/manifest_schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "id": {"type": "string"},
+    "name": {"type": "string"},
+    "version": {"type": "string"},
+    "permissions": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "signature": {"type": "string"}
+  },
+  "required": ["id", "name", "version", "permissions"],
+  "additionalProperties": false
+}

--- a/tests/test_plugin_security.py
+++ b/tests/test_plugin_security.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import pytest
 from pathlib import Path
+from jsonschema.exceptions import ValidationError
 
 from core.plugins import load_manifest, PluginManifest
 
@@ -58,3 +59,12 @@ def test_reject_invalid_signature(tmp_path):
     with pytest.raises(ValueError):
         load_manifest(manifest_path)
     os.environ.pop("PLUGIN_SIGNING_KEY")
+
+
+def test_schema_validation_error(tmp_path):
+    """Manifest missing required fields should raise ValidationError."""
+    data = {"id": "demo"}
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(data))
+    with pytest.raises(ValidationError):
+        load_manifest(manifest_path)


### PR DESCRIPTION
## Summary
- validate plugin manifests with JSON schema
- enforce schema in `load_manifest`
- update plugin security tests to cover schema validation
- document plugin manifest schema in README

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686c456a1b20832a93e3f7bf8843722f