### PR TITLE
Add CLI list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Planner decides what to build next. The Executor writes files and configures CI/
 4. **Start the Orchestrator**
    ```bash
    python -m ai_swa.orchestrator --config config.yaml start
+   # List tasks
+   python -m ai_swa.orchestrator list
    # Check status
    python -m ai_swa.orchestrator status
    # Later stop it
@@ -88,6 +90,7 @@ Planner decides what to build next. The Executor writes files and configures CI/
 
 ```
 python -m ai_swa.orchestrator --config config.yaml start
+python -m ai_swa.orchestrator list
 python -m ai_swa.orchestrator status
 python -m ai_swa.orchestrator stop
 ```

--- a/ai_swa/orchestrator.py
+++ b/ai_swa/orchestrator.py
@@ -1,4 +1,8 @@
-"""CLI entry point for the AI-SWA orchestrator."""
+"""CLI entry point for the AI-SWA orchestrator.
+
+This module exposes the same CLI as :mod:`core.cli`. Available
+subcommands include ``start``, ``stop``, ``status`` and ``list``.
+"""
 from core.cli import build_parser, main as cli_main
 
 __all__ = ["build_parser", "main"]

--- a/core/cli.py
+++ b/core/cli.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 from .orchestrator import Orchestrator
 from .memory import Memory
+from dataclasses import asdict
+import yaml
 from .planner import Planner
 from .executor import Executor
 from .reflector import Reflector
@@ -52,6 +54,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--pid-file",
         default="orchestrator.pid",
         help="File containing orchestrator PID",
+    )
+
+    list_cmd = subparsers.add_parser("list", help="List tasks from tasks.yml")
+    list_cmd.add_argument(
+        "--tasks",
+        default="tasks.yml",
+        help="Path to tasks.yml",
     )
 
     # Internal command used by "start"; not exposed in docs
@@ -141,6 +150,13 @@ def main(argv=None) -> int:
             pid_path.unlink(missing_ok=True)
             return 1
         print(f"Orchestrator running with PID {pid}")
+        return 0
+
+    if args.command == "list":
+        memory = Memory(Path("state.json"))
+        tasks = memory.load_tasks(args.tasks)
+        data = [asdict(t) for t in tasks]
+        yaml.safe_dump(data, sys.stdout, sort_keys=False)
         return 0
 
     if args.command == "_run":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+import yaml
 from pathlib import Path
 
 
@@ -92,3 +93,35 @@ def test_cli_start_missing_config(tmp_path):
         str(tmp_path / "missing.yaml"),
     ], tmp_path, env)
     assert result.returncode != 0
+
+
+def test_cli_list(tmp_path):
+    tasks = [
+        {
+            "id": 1,
+            "description": "test task",
+            "dependencies": [],
+            "priority": 1,
+            "status": "pending",
+        }
+    ]
+    tasks_file = tmp_path / "tasks.yml"
+    tasks_file.write_text(yaml.safe_dump(tasks, sort_keys=False))
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    result = _run(
+        [
+            sys.executable,
+            "-m",
+            "ai_swa.orchestrator",
+            "list",
+            "--tasks",
+            str(tasks_file),
+        ],
+        tmp_path,
+        env,
+    )
+    assert result.returncode == 0
+    data = yaml.safe_load(result.stdout)
+    assert data[0]["id"] == 1
+    assert data[0]["description"] == "test task"


### PR DESCRIPTION
## Summary
- extend CLI with `list` command using `Memory`
- document new command in `README` and orchestrator module
- test that the CLI prints tasks

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686c4766971c832a8756df35689c72ee