### PR TITLE
Add orchestrator REST API service

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -61,6 +61,17 @@ def main(argv=None):
     orchestrator.run()
 ```
 
+### Orchestrator API
+`services.orchestrator_api` exposes REST endpoints to start, stop and
+check the status of the orchestrator. It simply spawns the CLI
+subprocess using `uvicorn` as a container entrypoint.
+
+```
+POST /start   -> launch orchestrator process
+POST /stop    -> terminate the process
+GET  /status  -> return running PID or false
+```
+
 ### Memory
 Simple persistence helper for storing JSON state on disk. The API exposes
 `load()`/`save()` for generic JSON data and `load_tasks()`/`save_tasks()`

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Planner decides what to build next. The Executor writes files and configures CI/
    # Later stop it
    python -m ai_swa.orchestrator stop
    ```
+   The `orchestrator-api` service exposes equivalent REST endpoints
+   (`/start`, `/stop`, `/status`) when running under Docker Compose.
 5. **Explore the Blueprint** – Open `ARCHITECTURE.md` to see components and dependency rationales.
 6. **Watch It Evolve** – Each execution may introduce new tasks or propose refactors. Review and merge the generated commit.
 7. **Run with Docker Compose**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,14 @@ services:
       - broker
     ports:
       - "9001:9001"
+  orchestrator-api:
+    build:
+      context: .
+      dockerfile: orchestrator_api/Dockerfile
+    depends_on:
+      - orchestrator
+    ports:
+      - "8002:8002"
   io-service:
     build: ./services/node
     environment:

--- a/orchestrator_api/Dockerfile
+++ b/orchestrator_api/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY services/orchestrator_api.py ./services/orchestrator_api.py
+COPY core ./core
+COPY ai_swa ./ai_swa
+COPY config.yaml ./
+EXPOSE 8002
+ENTRYPOINT ["uvicorn", "services.orchestrator_api:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/services/orchestrator_api.py
+++ b/services/orchestrator_api.py
@@ -1,0 +1,70 @@
+"""REST API to control the Orchestrator."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from typing import Optional
+
+from fastapi import FastAPI, HTTPException, Depends
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+from core.config import load_config
+from core.security import verify_api_key, require_role, User
+from core.telemetry import setup_telemetry
+
+app = FastAPI()
+config = load_config()
+setup_telemetry(service_name="orchestrator_api", metrics_port=0)
+FastAPIInstrumentor.instrument_app(app)
+
+_proc: Optional[subprocess.Popen] = None
+
+
+def _is_running() -> bool:
+    return _proc is not None and _proc.poll() is None
+
+
+@app.post("/start")
+def start_orchestrator(
+    _: None = Depends(verify_api_key),
+    __: User = Depends(require_role(["admin"])),
+):
+    """Start the orchestrator subprocess."""
+    global _proc
+    if _is_running():
+        raise HTTPException(status_code=400, detail="Already running")
+    cmd = [sys.executable, "-m", "ai_swa.orchestrator", "_run", "--config", "config.yaml"]
+    env = os.environ.copy()
+    env.setdefault("PYTHONPATH", str(os.getcwd()))
+    _proc = subprocess.Popen(cmd, env=env)
+    return {"pid": _proc.pid}
+
+
+@app.post("/stop")
+def stop_orchestrator(
+    _: None = Depends(verify_api_key),
+    __: User = Depends(require_role(["admin"])),
+):
+    """Terminate the orchestrator subprocess."""
+    global _proc
+    if not _is_running():
+        raise HTTPException(status_code=400, detail="Not running")
+    os.kill(_proc.pid, signal.SIGTERM)
+    try:
+        _proc.wait(timeout=5)
+    finally:
+        pid = _proc.pid
+        _proc = None
+    return {"pid": pid}
+
+
+@app.get("/status")
+def status(_: None = Depends(verify_api_key)):
+    """Return whether the orchestrator is running."""
+    if _is_running():
+        return {"running": True, "pid": _proc.pid}
+    return {"running": False}
+

--- a/tests/test_orchestrator_api.py
+++ b/tests/test_orchestrator_api.py
@@ -1,0 +1,44 @@
+import os
+import time
+from importlib import reload
+
+from fastapi.testclient import TestClient
+
+
+def setup_module(module):
+    os.environ["METRICS_PORT"] = "0"
+    global api
+    import services.orchestrator_api as api_mod
+    api = reload(api_mod)
+
+
+def teardown_module(module):
+    if api._proc and api._proc.poll() is None:
+        api._proc.terminate()
+        api._proc.wait(timeout=5)
+
+
+def test_start_stop_status():
+    client = TestClient(api.app)
+
+    # initially not running
+    resp = client.get("/status")
+    assert resp.status_code == 200
+    assert resp.json()["running"] is False
+
+    resp = client.post("/start")
+    assert resp.status_code == 200
+    pid = resp.json()["pid"]
+    assert isinstance(pid, int)
+
+    # give process a moment
+    time.sleep(0.2)
+
+    resp = client.get("/status")
+    assert resp.json()["running"] is True
+
+    resp = client.post("/stop")
+    assert resp.status_code == 200
+
+    resp = client.get("/status")
+    assert resp.json()["running"] is False


### PR DESCRIPTION
## Summary
- expose Orchestrator control via `services/orchestrator_api.py`
- add Dockerfile for new service and wire it into compose file
- integration test covering start/stop behavior
- document the API in `ARCHITECTURE.md` and mention it in `README.md`

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686c47566ca0832aaac1beebbd64f7b7