### PR TITLE
Add plugin packaging utility

### DIFF
--- a/docs/plugins/permissions.md
+++ b/docs/plugins/permissions.md
@@ -11,3 +11,14 @@ The host validates that all requested permissions are allowed and, when a signin
 key is configured via the `PLUGIN_SIGNING_KEY` environment variable, verifies the
 signature. Plugins lacking a valid signature are rejected when signing is
 enabled.
+
+## Packaging Plugins
+
+Use `scripts/package_plugin.py` to bundle a plugin for distribution. Run:
+
+```bash
+python scripts/package_plugin.py plugins/example_plugin
+```
+
+The script creates `dist/<id>-<version>.zip` containing `manifest.json` and all
+Python source files while excluding compiled artifacts.

--- a/tests/test_plugin_security.py
+++ b/tests/test_plugin_security.py
@@ -3,6 +3,7 @@ import json
 import base64
 import hashlib
 import hmac
+import zipfile
 import pytest
 from pathlib import Path
 from jsonschema.exceptions import ValidationError
@@ -68,3 +69,18 @@ def test_schema_validation_error(tmp_path):
     manifest_path.write_text(json.dumps(data))
     with pytest.raises(ValidationError):
         load_manifest(manifest_path)
+
+
+def test_package_example_plugin(tmp_path):
+    from scripts.package_plugin import create_plugin_archive
+
+    archive_path = create_plugin_archive(Path("plugins/example_plugin"))
+    assert archive_path.exists()
+    with zipfile.ZipFile(archive_path) as zf:
+        names = zf.namelist()
+
+    assert "manifest.json" in names
+    assert "plugin.py" in names
+    for name in names:
+        assert not name.endswith(".pyc")
+        assert "__pycache__" not in name


### PR DESCRIPTION
## Summary
- add `package_plugin.py` script to build zip archives under `dist/`
- document plugin packaging workflow
- test packaging with example plugin

## Testing
- `pip install -q -r requirements.txt`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6ee86c98832a920b93a5cb8f8ef5