### PR TITLE
Add orchestration metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,11 @@ scrape_configs:
 
 Use the appropriate hostnames if running under Docker Compose or Kubernetes.
 
+The Orchestrator component exports a Prometheus counter named
+`tasks_executed_total` which increments each time a task completes.
+This metric is served alongside the other service metrics on the
+OpenTelemetry endpoint configured in `core/telemetry.py`.
+
 ### Example usage
 
 Run the services directly with overrides:

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -30,6 +30,9 @@ class Orchestrator:
         self._runs = meter.create_counter(
             "orchestrator_runs_total", description="Number of orchestrator loops"
         )
+        self._tasks_executed = meter.create_counter(
+            "tasks_executed_total", description="Number of executed tasks"
+        )
         self._tracer = trace.get_tracer(__name__)
 
     # ------------------------------------------------------------------
@@ -98,6 +101,7 @@ class Orchestrator:
             )
 
         print(f"Orchestrator: Task '{getattr(task, 'id', 'N/A')}' completed.")
+        self._tasks_executed.add(1, {"task.id": getattr(task, "id", "N/A")})
 
         audit_results = self.auditor.audit([self._task_to_dict(t) for t in tasks])
         if audit_results:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,5 +1,9 @@
 import requests
 from core.telemetry import setup_telemetry
+from core.orchestrator import Orchestrator
+from core.task import Task
+from core.self_auditor import SelfAuditor
+from unittest.mock import MagicMock
 
 
 def test_setup_telemetry() -> None:
@@ -7,5 +11,45 @@ def test_setup_telemetry() -> None:
     try:
         response = requests.get(f"http://localhost:{server.server_port}/metrics")
         assert response.status_code == 200
+    finally:
+        server.shutdown()
+
+
+def test_tasks_executed_counter() -> None:
+    server, _ = setup_telemetry(metrics_port=0)
+    try:
+        task = Task(id="1", description="d", component="c", dependencies=[], priority=1, status="pending")
+
+        class DummyPlanner:
+            def __init__(self):
+                self.called = False
+
+            def plan(self, tasks):
+                if not self.called:
+                    self.called = True
+                    return tasks[0]
+                return None
+
+        class DummyExecutor:
+            def execute(self, task):
+                pass
+
+        class DummyReflector:
+            def run_cycle(self, tasks):
+                return tasks
+
+        memory = MagicMock()
+        memory.load_tasks.return_value = [task]
+        memory.save_tasks.return_value = None
+
+        auditor = MagicMock(spec=SelfAuditor)
+        auditor.audit.return_value = []
+
+        orch = Orchestrator(DummyPlanner(), DummyExecutor(), DummyReflector(), memory, auditor)
+        orch.run("tasks.yml")
+
+        resp = requests.get(f"http://localhost:{server.server_port}/metrics")
+        lines = [l for l in resp.text.splitlines() if l.startswith("tasks_executed_total")]
+        assert lines and float(lines[0].split()[-1]) >= 1
     finally:
         server.shutdown()


### PR DESCRIPTION
## Summary
- track completed tasks in `Orchestrator`
- expose metric via telemetry
- verify counter increments in unit test
- document `tasks_executed_total` metric

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686cb3a29ee8832aab5b8b330cfaaf51