### PR TITLE
Add tasks executed metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ scrape_configs:
 
 Use the appropriate hostnames if running under Docker Compose or Kubernetes.
 
+The orchestrator exposes a `tasks_executed_total` counter via the same
+Prometheus endpoint. This metric increases each time a task finishes
+execution, allowing dashboards to track overall progress.
+
 ### Example usage
 
 Run the services directly with overrides:

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -30,6 +30,9 @@ class Orchestrator:
         self._runs = meter.create_counter(
             "orchestrator_runs_total", description="Number of orchestrator loops"
         )
+        self._tasks_executed = meter.create_counter(
+            "tasks_executed_total", description="Number of tasks executed successfully"
+        )
         self._tracer = trace.get_tracer(__name__)
 
     # ------------------------------------------------------------------
@@ -98,6 +101,7 @@ class Orchestrator:
             )
 
         print(f"Orchestrator: Task '{getattr(task, 'id', 'N/A')}' completed.")
+        self._tasks_executed.add(1)
 
         audit_results = self.auditor.audit([self._task_to_dict(t) for t in tasks])
         if audit_results:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,11 +1,67 @@
 import requests
+import pytest
 from core.telemetry import setup_telemetry
 
 
-def test_setup_telemetry() -> None:
+@pytest.fixture
+def telemetry_server():
+    from opentelemetry.metrics import _internal as metrics_internal
+    from opentelemetry import trace as trace_api
+
+    metrics_internal._METER_PROVIDER_SET_ONCE._done = False
+    metrics_internal._METER_PROVIDER = None
+    trace_api._TRACER_PROVIDER_SET_ONCE._done = False
+    trace_api._TRACER_PROVIDER = None
+
     server, _ = setup_telemetry(metrics_port=0)
-    try:
-        response = requests.get(f"http://localhost:{server.server_port}/metrics")
-        assert response.status_code == 200
-    finally:
-        server.shutdown()
+    yield server
+    server.shutdown()
+
+
+def test_setup_telemetry(telemetry_server) -> None:
+    response = requests.get(
+        f"http://localhost:{telemetry_server.server_port}/metrics"
+    )
+    assert response.status_code == 200
+
+
+def test_tasks_executed_metric(telemetry_server, tmp_path):
+    from core.orchestrator import Orchestrator
+    from core.task import Task
+    from unittest.mock import MagicMock
+
+    task = Task(
+        id="1",
+        description="",
+        component="core",
+        dependencies=[],
+        priority=1,
+        status="pending",
+    )
+
+    memory = MagicMock()
+    memory.load_tasks.return_value = [task]
+    planner = MagicMock()
+    planner.plan.side_effect = [task, None]
+    reflector = MagicMock()
+    reflector.run_cycle.return_value = [task]
+    executor = MagicMock()
+    auditor = MagicMock()
+    auditor.audit.return_value = []
+
+    orch = Orchestrator(planner, executor, reflector, memory, auditor)
+
+    def fetch_count() -> float:
+        resp = requests.get(
+            f"http://localhost:{telemetry_server.server_port}/metrics"
+        )
+        for line in resp.text.splitlines():
+            if line.startswith("tasks_executed_total"):
+                return float(line.split()[-1])
+        return 0.0
+
+    orch.run(str(tmp_path / "tasks.yml"))
+    after = fetch_count()
+
+    assert after == 1.0
+


### PR DESCRIPTION
## Summary
- instrument orchestrator to record `tasks_executed_total`
- document the new metric in README
- expose the metric in telemetry tests
- verify counter via Prometheus endpoint

## Testing
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_686cd757bea8832a93ad2ad583e057a9