### PR TITLE
Implement centralized logging

### DIFF
--- a/broker/main.py
+++ b/broker/main.py
@@ -13,6 +13,7 @@ are created on startup: ``tasks`` for task metadata and ``task_results`` for
 worker output.
 """
 
+import logging
 import sqlite3
 from fastapi import FastAPI, HTTPException, Depends, Request
 from fastapi.responses import JSONResponse
@@ -22,9 +23,12 @@ from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from core.telemetry import setup_telemetry
 from core.security import verify_api_key, verify_token, require_role, User
 from core.config import load_config
+from core.log_utils import configure_logging
 
 config = load_config()
 DB_PATH = config["broker"]["db_path"]
+configure_logging()
+logger = logging.getLogger(__name__)
 
 app = FastAPI()
 setup_telemetry(service_name="broker", metrics_port=int(config["broker"]["metrics_port"]))

--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -80,7 +80,7 @@ def main():
         logfile.parent.mkdir(exist_ok=True)
         configure_logging(logfile=logfile)
     except OSError as exc:
-        print(f"[ERROR] {exc}")
+        logging.error("[ERROR] %s", exc)
         sys.exit(2)
 
     schema, tasks = load_schema_and_tasks(Path("tasks.yml"))

--- a/core/executor.py
+++ b/core/executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import subprocess
 import shlex
 from datetime import datetime
@@ -14,6 +15,7 @@ class Executor:
 
     def __init__(self) -> None:
         meter = metrics.get_meter_provider().get_meter(__name__)
+        self.logger = logging.getLogger(__name__)
         self._tasks_executed = meter.create_counter(
             "tasks_executed_total", description="Number of executed tasks"
         )
@@ -37,11 +39,11 @@ class Executor:
         """
 
         if hasattr(task, "description"):
-            print(f"Executing task: {task.description}")
+            self.logger.info("Executing task: %s", task.description)
         elif hasattr(task, "id"):
-            print(f"Executing task ID: {task.id} (No description found)")
+            self.logger.info("Executing task ID: %s (No description found)", task.id)
         else:
-            print("Executing task: (No description or ID found)")
+            self.logger.info("Executing task: (No description or ID found)")
 
         command = getattr(task, "command", None)
         if not command:

--- a/core/log_utils.py
+++ b/core/log_utils.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 import logging
+from logging.config import fileConfig
 from pathlib import Path
 from typing import Optional
 
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parents[1] / "logging.conf"
 
-def configure_logging(logfile: Optional[Path] = None, level: int = logging.INFO) -> None:
+
+def configure_logging(
+    logfile: Optional[Path] = None,
+    level: int = logging.INFO,
+    config_path: Optional[Path] = None,
+) -> None:
     """Configure the root logger with a standard format.
 
     Parameters
@@ -20,10 +27,19 @@ def configure_logging(logfile: Optional[Path] = None, level: int = logging.INFO)
     if logging.getLogger().hasHandlers():
         return
 
-    params = {
-        "level": level,
-        "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    }
-    if logfile:
-        params["filename"] = str(logfile)
-    logging.basicConfig(**params)
+    cfg = Path(config_path or DEFAULT_CONFIG_PATH)
+    if cfg.exists():
+        fileConfig(cfg, disable_existing_loggers=False)
+        if logfile:
+            for handler in logging.getLogger().handlers:
+                if hasattr(handler, "baseFilename"):
+                    handler.baseFilename = str(logfile)
+        logging.getLogger().setLevel(level)
+    else:
+        params = {
+            "level": level,
+            "format": "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        }
+        if logfile:
+            params["filename"] = str(logfile)
+        logging.basicConfig(**params)

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -68,16 +68,17 @@ class Orchestrator:
             message = (
                 f"Orchestrator: Task '{getattr(task, 'id', 'N/A')}' blocked by Ethical Sentinel."
             )
-            print(message)
             self.logger.info(message)
             return
         if hasattr(task, "status"):
             task.status = "in_progress"
             self.memory.save_tasks(tasks, tasks_file)
         else:
-            print(f"Warning: Task '{getattr(task, 'id', 'N/A')}' has no 'status' attribute.")
+            self.logger.warning(
+                "Task '%s' has no 'status' attribute.", getattr(task, "id", "N/A")
+            )
 
-        print(f"Orchestrator: Executing task '{getattr(task, 'id', 'N/A')}'.")
+        self.logger.info("Orchestrator: Executing task '%s'.", getattr(task, "id", "N/A"))
         try:
             self.executor.execute(task)
         except (RuntimeError, OSError, subprocess.SubprocessError) as exc:
@@ -96,11 +97,12 @@ class Orchestrator:
             task.status = "done"
             self.memory.save_tasks(tasks, tasks_file)
         else:
-            print(
-                f"Warning: Task '{getattr(task, 'id', 'N/A')}' has no 'status' attribute to mark as done."
+            self.logger.warning(
+                "Task '%s' has no 'status' attribute to mark as done.",
+                getattr(task, "id", "N/A"),
             )
 
-        print(f"Orchestrator: Task '{getattr(task, 'id', 'N/A')}' completed.")
+        self.logger.info("Orchestrator: Task '%s' completed.", getattr(task, "id", "N/A"))
         self._tasks_executed.add(1)
 
         audit_results = self.auditor.audit([self._task_to_dict(t) for t in tasks])
@@ -120,11 +122,14 @@ class Orchestrator:
             while True:
                 next_task = self.planner.plan(tasks)
                 if next_task is None:
-                    print("Orchestrator: No actionable tasks. Halting.")
+                    self.logger.info("Orchestrator: No actionable tasks. Halting.")
                     break
 
-                print(f"Orchestrator: Task '{getattr(next_task, 'id', 'N/A')}' selected for execution.")
+                self.logger.info(
+                    "Orchestrator: Task '%s' selected for execution.",
+                    getattr(next_task, "id", "N/A"),
+                )
                 self._execute_task(next_task, tasks, tasks_file)
                 self._runs.add(1)
 
-            print("Orchestrator: Run finished.")
+            self.logger.info("Orchestrator: Run finished.")

--- a/core/self_auditor.py
+++ b/core/self_auditor.py
@@ -281,9 +281,10 @@ if __name__ == "__main__":  # pragma: no cover - manual testing helper
     auditor = SelfAuditor()
     sample_files = list(Path(".").rglob("*.py"))[:5]
     metrics = auditor.analyze(sample_files)
+    logger = logging.getLogger(__name__)
     for file, data in metrics.items():
-        print(f"\n{file}:")
-        print(f"  Max Complexity: {data['max_complexity']}")
-        print(f"  Needs Refactor: {data['needs_refactor']}")
+        logger.info("%s:", file)
+        logger.info("  Max Complexity: %s", data["max_complexity"])
+        logger.info("  Needs Refactor: %s", data["needs_refactor"])
         if data["complexity_violations"]:
-            print(f"  Violations: {len(data['complexity_violations'])}")
+            logger.info("  Violations: %d", len(data["complexity_violations"]))

--- a/logging.conf
+++ b/logging.conf
@@ -1,0 +1,22 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler
+
+[formatters]
+keys=defaultFormatter
+
+[logger_root]
+level=INFO
+handlers=consoleHandler
+
+[handler_consoleHandler]
+class=StreamHandler
+level=INFO
+formatter=defaultFormatter
+args=(sys.stderr,)
+
+[formatter_defaultFormatter]
+format=%(asctime)s - %(name)s - %(levelname)s - %(message)s
+datefmt=

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,7 @@ def test_cli_start_status_stop(tmp_path):
         str(pid_file),
     ], tmp_path, env)
     assert status.returncode == 0
-    assert "running" in status.stdout.lower()
+    assert "running" in status.stderr.lower()
 
     stop = _run([
         sys.executable,

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock
 from core.executor import Executor
 from core.task import Task
 
@@ -9,9 +9,9 @@ class TestExecutor(unittest.TestCase):
 
     def setUp(self):
         self.executor = Executor()
+        self.executor.logger = MagicMock()
 
-    @patch('builtins.print')
-    def test_execute_task_with_description(self, mock_print):
+    def test_execute_task_with_description(self):
         task = Task(
             id="t1",
             description="Task One Description",
@@ -21,10 +21,9 @@ class TestExecutor(unittest.TestCase):
             status="pending",
         )
         self.executor.execute(task)
-        mock_print.assert_called_once_with("Executing task: Task One Description")
+        self.executor.logger.info.assert_called_once_with("Executing task: %s", "Task One Description")
 
-    @patch('builtins.print')
-    def test_execute_task_with_id_no_description(self, mock_print):
+    def test_execute_task_with_id_no_description(self):
         task = Task(
             id="t2",
             description="",
@@ -37,10 +36,9 @@ class TestExecutor(unittest.TestCase):
         if hasattr(task, 'description'):
             delattr(task, 'description')
         self.executor.execute(task)
-        mock_print.assert_called_once_with("Executing task ID: t2 (No description found)")
+        self.executor.logger.info.assert_called_once_with("Executing task ID: %s (No description found)", "t2")
 
-    @patch('builtins.print')
-    def test_execute_task_no_description_no_id(self, mock_print):
+    def test_execute_task_no_description_no_id(self):
         task = Task(
             id=0,
             description="",
@@ -55,10 +53,9 @@ class TestExecutor(unittest.TestCase):
         if hasattr(task, 'id'):
             delattr(task, 'id')
         self.executor.execute(task)
-        mock_print.assert_called_once_with("Executing task: (No description or ID found)")
+        self.executor.logger.info.assert_called_once_with("Executing task: (No description or ID found)")
 
-    @patch('builtins.print')
-    def test_execute_task_as_dict_with_description(self, mock_print):
+    def test_execute_task_as_dict_with_description(self):
         # The Executor expects an object with attributes. Using the Task
         # dataclass mimics this interface and keeps the test focused on the
         # print behavior rather than attribute lookups.
@@ -71,10 +68,9 @@ class TestExecutor(unittest.TestCase):
             status="pending",
         )
         self.executor.execute(task)
-        mock_print.assert_called_once_with("Executing task: Dict Task Description")
+        self.executor.logger.info.assert_called_once_with("Executing task: %s", "Dict Task Description")
 
-    @patch('builtins.print')
-    def test_execute_task_as_dict_with_id_no_description(self, mock_print):
+    def test_execute_task_as_dict_with_id_no_description(self):
         task_obj = Task(
             id="d2",
             description="",
@@ -86,10 +82,9 @@ class TestExecutor(unittest.TestCase):
         if hasattr(task_obj, 'description'):
             delattr(task_obj, 'description')
         self.executor.execute(task_obj)
-        mock_print.assert_called_once_with("Executing task ID: d2 (No description found)")
+        self.executor.logger.info.assert_called_once_with("Executing task ID: %s (No description found)", "d2")
 
-    @patch('builtins.print')
-    def test_execute_task_object_with_other_attributes(self, mock_print):
+    def test_execute_task_object_with_other_attributes(self):
         task = Task(
             id="t_other",
             description="Other attributes test",
@@ -99,7 +94,7 @@ class TestExecutor(unittest.TestCase):
             status="pending",
         )
         self.executor.execute(task)
-        mock_print.assert_called_once_with("Executing task: Other attributes test")
+        self.executor.logger.info.assert_called_once_with("Executing task: %s", "Other attributes test")
 
     def test_execute_task_with_command_creates_log(self):
         import tempfile

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,12 @@
+import logging
+from core.log_utils import configure_logging
+
+
+def test_logging_configuration(tmp_path):
+    logging.getLogger().handlers.clear()
+    logfile = tmp_path / "test.log"
+    configure_logging(logfile=logfile)
+    handlers = logging.getLogger().handlers
+    assert handlers, "Logging not configured"
+    fmt = handlers[0].formatter._fmt
+    assert fmt == "%(asctime)s - %(name)s - %(levelname)s - %(message)s"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -197,7 +197,8 @@ class TestOrchestrator(unittest.TestCase):
         self.mock_reflector.run_cycle.return_value = [] # No new tasks from reflector
         self.mock_planner.plan.return_value = None # Planner finds nothing to do
 
-        with patch('builtins.print') as mock_print:
+        self.orchestrator.logger = MagicMock()
+        with patch('builtins.print'):
             self.orchestrator.run(tasks_file)
 
         self.mock_memory.load_tasks.assert_called_once_with(tasks_file)
@@ -213,7 +214,8 @@ class TestOrchestrator(unittest.TestCase):
         self.mock_reflector.run_cycle.return_value = initial_tasks # Reflector adds no new tasks
         self.mock_planner.plan.return_value = None # Planner immediately says nothing to do
 
-        with patch('builtins.print') as mock_print:
+        self.orchestrator.logger = MagicMock()
+        with patch('builtins.print'):
             self.orchestrator.run(tasks_file)
 
         self.mock_memory.load_tasks.assert_called_once_with(tasks_file)
@@ -278,14 +280,15 @@ class TestOrchestrator(unittest.TestCase):
         self.mock_reflector.run_cycle.return_value = [task_no_id]
         self.mock_planner.plan.side_effect = [task_no_id, None]
 
-        with patch('builtins.print') as mock_print:
+        self.orchestrator.logger = MagicMock()
+        with patch("builtins.print"):
             self.orchestrator.run(tasks_file)
 
         self.mock_executor.execute.assert_called_once_with(task_no_id)
         self.assertEqual(task_no_id.status, 'done')
         self.assertEqual(self.mock_memory.save_tasks.call_count, 3)
-        mock_print.assert_any_call("Orchestrator: Task 'N/A' selected for execution.")
-        mock_print.assert_any_call("Orchestrator: Executing task 'N/A'.")
+        self.orchestrator.logger.info.assert_any_call("Orchestrator: Task '%s' selected for execution.", "N/A")
+        self.orchestrator.logger.info.assert_any_call("Orchestrator: Executing task '%s'.", "N/A")
 
     def test_reflector_returns_invalid_data_raises_error(self):
         tasks_file = "tasks_invalid.yml"

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from pathlib import Path
 from core.sentinel import EthicalSentinel
 from core.orchestrator import Orchestrator
@@ -37,11 +37,9 @@ def test_policy_loading_and_blocking(tmp_path: Path):
     orch.logger = MagicMock()
     message = "Orchestrator: Task 'block' blocked by Ethical Sentinel."
 
-    with patch('builtins.print') as mock_print:
-        orch.run("tasks.yml")
+    orch.run("tasks.yml")
 
     assert sentinel.blocked_actions == {"block"}
-    mock_print.assert_any_call(message)
-    orch.logger.info.assert_called_with(message)
+    orch.logger.info.assert_any_call(message)
     # Executor should not be called because sentinel blocks the action
     executor.execute.assert_not_called()

--- a/worker/main.py
+++ b/worker/main.py
@@ -6,14 +6,18 @@ an isolated subprocess. The worker then posts the command's ``stdout``,
 ``stderr`` and ``exit_code`` back to the broker.
 """
 
+import logging
 import requests
 import subprocess
 from core.telemetry import setup_telemetry
 from core.config import load_config
+from core.log_utils import configure_logging
 
 config = load_config()
 BROKER_URL = config["worker"]["broker_url"]
 setup_telemetry(service_name="worker", metrics_port=int(config["worker"]["metrics_port"]))
+configure_logging()
+logger = logging.getLogger(__name__)
 
 
 def fetch_tasks():
@@ -25,6 +29,7 @@ def fetch_tasks():
 
 
 def main():
+    logger.info("Worker starting")
     tasks = fetch_tasks()
     for task in tasks:
         command = task.get("command")
@@ -32,6 +37,7 @@ def main():
             result = subprocess.run(
                 command, shell=True, check=False, capture_output=True, text=True
             )
+            logger.info("Executed command for task %s", task["id"])
             api_key = config["security"]["api_key"]
             headers = {"X-API-Key": api_key} if api_key else {}
             requests.post(
@@ -43,6 +49,7 @@ def main():
                 },
                 headers=headers,
             ).raise_for_status()
+            logger.info("Reported result for task %s", task["id"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- configure logging via new `logging.conf`
- apply `configure_logging` across orchestrator, worker and broker
- switch `print` statements in core modules to logging
- add unit tests verifying log formatting and update existing tests

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: requests.exceptions.ConnectionError in test_worker_broker_flow)*

------
https://chatgpt.com/codex/tasks/task_e_686ce6bb68d4832a98d31e57460486a5