### PR TITLE
Add Express health endpoint with uptime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -318,8 +318,8 @@ under ``services/node`` and is started independently. A small Python
 client in ``core.io_client`` allows the orchestrator or other modules to
 invoke this service when needed. The Node process also runs a small Express
 server on the metrics port (default ``9100``) exposing ``/metrics`` for
-Prometheus scraping and ``/health`` which returns ``{"status": "ok"}`` for
-basic health checks.
+Prometheus scraping and ``/health`` which returns JSON including service
+``uptime`` and ``status`` for basic health checks.
 
 ### Vision Engine
 Ranks epics using Weighted Shortest Job First (WSJF) scores. An optional

--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ Planner decides what to build next. The Executor writes files and configures CI/
    This starts the orchestrator, broker, worker, and Node I/O service containers.
    Environment variables like `BROKER_URL`, `DB_PATH` and metrics ports are set
    in the compose file so you can simply run `docker-compose up` on subsequent
-   launches for local development. The Node service also exposes `GET /health`
-   on its metrics port (default `9100`) for container health checks.
+   launches for local development. The Node service exposes its gRPC API on
+   port `50051` and provides `GET /health` on the metrics port (default `9100`)
+   for container health checks.
 8. **Run End-to-End Tests**
    ```bash
    pytest tests/e2e/ --maxfail=1 --disable-warnings -q

--- a/services/node/io_server.js
+++ b/services/node/io_server.js
@@ -50,7 +50,7 @@ function startHttpServer(port) {
     res.end(await client.register.metrics());
   });
   app.get('/health', (_req, res) => {
-    res.json({ status: 'ok' });
+    res.json({ status: 'ok', uptime: process.uptime() });
   });
   app.listen(port, () => {
     console.log(`HTTP server running on ${port}`);

--- a/tasks.yml
+++ b/tasks.yml
@@ -673,7 +673,7 @@
   priority: 2
   acceptance_criteria:
   - GET /health returns 200 with JSON status
-  status: pending
+  status: done
   assigned_to: null
   epic: Reliability
 - id: 121

--- a/tests/test_node_health.py
+++ b/tests/test_node_health.py
@@ -10,4 +10,6 @@ def test_health_endpoint(node_server):
     except requests.RequestException:
         pytest.skip("health endpoint unavailable")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    data = response.json()
+    assert data["status"] == "ok"
+    assert "uptime" in data and data["uptime"] >= 0


### PR DESCRIPTION
## Summary
- add uptime info to Node service `/health` endpoint
- document Node ports in README and architecture reference
- test the `/health` endpoint for uptime
- mark Node health check task done

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf0001acc832aa57e99a677211d4b