### PR TITLE
Document configuration details

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -271,6 +271,19 @@ flowchart TD
     O --> R[Orchestrator.run]
 ```
 
+## Configuration Flow
+```mermaid
+flowchart TD
+    Start --> LoadFile[Read config.yaml]
+    LoadFile --> ApplyEnv[Apply environment variables]
+    ApplyEnv --> Ready[Return merged config]
+```
+
+Configuration is loaded with `core.config.load_config()` which merges
+`config.yaml` with any environment overrides. See the
+[README Configuration](README.md#configuration) section for the list of
+available variables.
+
 ### Diff Utility
 Utility functions ``generate_diff`` and ``generate_file_diff`` in
 ``core.diff_utils`` emit unified diffs when file contents change.

--- a/README.md
+++ b/README.md
@@ -107,20 +107,57 @@ python -m ai_swa.orchestrator stop
 ## Configuration
 
 AI-SWA loads settings from `config.yaml` by default. Set `CONFIG_FILE` to use a
-different file. Environment variables listed below override values from the
-configuration file:
+different file. Environment variables override values from the file so you can
+adjust settings per environment.
+
+### Required environment variables
+
+- `DB_PATH` – path to the broker SQLite database
+- `BROKER_URL` – broker service URL used by the worker and orchestrator
+
+### Optional environment variables
 
 | Variable | Description | Default |
 | --- | --- | --- |
-| `DB_PATH` | Path to the broker SQLite database | `tasks.db` |
-| `BROKER_URL` | Broker service URL used by the worker and orchestrator | `http://broker:8000` |
 | `BROKER_METRICS_PORT` | Port exposing broker Prometheus metrics | `9000` |
 | `WORKER_METRICS_PORT` | Port exposing worker Prometheus metrics | `9001` |
 | `METRICS_PORT` | Set both broker and worker metrics ports at once | *(unset)* |
 | `WORKER_CONCURRENCY` | Number of tasks the worker runs in parallel | `2` |
+| `NODE_HOST` | Hostname of the Node I/O service | `localhost` |
+| `NODE_PORT` | gRPC port of the Node I/O service | `50051` |
 | `API_KEY` | Shared API key required for API access | *(unset)* |
 | `API_TOKENS` | Comma separated tokens mapping to `username:role` | *(unset)* |
 | `PLUGIN_SIGNING_KEY` | HMAC key used to verify plugin manifests | *(unset)* |
+| `PLUGIN_POLICY_FILE` | Path to plugin policy JSON | `plugins/policy.json` |
+
+### Sample `config.yaml`
+
+```yaml
+broker:
+  db_path: tasks.db
+  metrics_port: 9000
+worker:
+  broker_url: http://broker:8000
+  metrics_port: 9001
+  concurrency: 2
+node:
+  host: localhost
+  port: 50051
+security:
+  api_key: null
+  api_tokens: null
+  plugin_signing_key: null
+```
+
+### Sample `.env`
+
+```env
+DB_PATH=tasks.db
+BROKER_URL=http://localhost:8000
+WORKER_CONCURRENCY=4
+API_KEY=changeme
+API_TOKENS=alice:admin,bob:viewer
+```
 
 The worker will execute up to `WORKER_CONCURRENCY` tasks simultaneously. This
 value defaults to `2` in `config.yaml` and can be overridden by the


### PR DESCRIPTION
## Summary
- document env vars in README and provide sample snippets
- add configuration flow section in ARCHITECTURE docs

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686cf3d102c0832a83752f770e64eebb