### PR TITLE
Implement EthicalSentinel policy enforcement

### DIFF
--- a/core/sentinel.py
+++ b/core/sentinel.py
@@ -1,14 +1,33 @@
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
+from jsonschema import validate
+
+from .log_utils import configure_logging
+
+DEFAULT_SCHEMA_PATH = Path(__file__).resolve().parents[1] / "policies/policy_schema.json"
 
 
 @dataclass
 class EthicalSentinel:
-    """Simple policy checker loading blocked actions from a JSON file."""
+    """Policy enforcement using a JSON policy definition."""
 
     policy_path: Path
+    audit_log: Path | None = None
+    policy_schema_path: Path = DEFAULT_SCHEMA_PATH
     blocked_actions: set[str] | None = None
+    logger: logging.Logger | None = None
+
+    def __post_init__(self) -> None:
+        configure_logging()
+        self.logger = logging.getLogger("policy_audit")
+        if self.audit_log and not self.logger.handlers:
+            handler = logging.FileHandler(self.audit_log)
+            handler.setFormatter(logging.Formatter("%(asctime)s - %(message)s"))
+            self.logger.addHandler(handler)
+        elif not self.logger.handlers:
+            self.logger.addHandler(logging.NullHandler())
 
     def load_policies(self) -> None:
         """Load blocked actions from the policy file."""
@@ -17,10 +36,17 @@ class EthicalSentinel:
             return
         with self.policy_path.open() as f:
             data = json.load(f)
+        if self.policy_schema_path.exists():
+            with self.policy_schema_path.open() as f:
+                schema = json.load(f)
+            validate(data, schema)
         self.blocked_actions = set(data.get("blocked_actions", []))
 
     def allows(self, action: str) -> bool:
         """Return True if ``action`` is permitted."""
         if self.blocked_actions is None:
             self.load_policies()
-        return action not in self.blocked_actions
+        allowed = action not in self.blocked_actions
+        if not allowed and self.logger:
+            self.logger.info("Action '%s' blocked by policy.", action)
+        return allowed

--- a/policies/policy_schema.json
+++ b/policies/policy_schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "blocked_actions": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "required": ["blocked_actions"],
+  "additionalProperties": false
+}

--- a/tasks.yml
+++ b/tasks.yml
@@ -862,7 +862,7 @@
   - The Sentinel can block an action that violates a defined policy.
   - Policy violations are logged to a dedicated audit stream.
   priority: 2
-  status: pending
+  status: done
   assigned_to: null
   epic: Governance
 - id: 137

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -1,7 +1,7 @@
 import json
 from unittest.mock import MagicMock
 from pathlib import Path
-from core.sentinel import EthicalSentinel
+from core.sentinel import EthicalSentinel, DEFAULT_SCHEMA_PATH
 from core.orchestrator import Orchestrator
 from core.task import Task
 from core.planner import Planner
@@ -14,7 +14,8 @@ from core.self_auditor import SelfAuditor
 def test_policy_loading_and_blocking(tmp_path: Path):
     policy = tmp_path / "policy.json"
     policy.write_text(json.dumps({"blocked_actions": ["block"]}))
-    sentinel = EthicalSentinel(policy)
+    audit = tmp_path / "audit.log"
+    sentinel = EthicalSentinel(policy, audit_log=audit, policy_schema_path=DEFAULT_SCHEMA_PATH)
 
     task = Task(id="block", description="", component="core", dependencies=[], priority=1, status="pending")
 
@@ -43,3 +44,4 @@ def test_policy_loading_and_blocking(tmp_path: Path):
     orch.logger.info.assert_any_call(message)
     # Executor should not be called because sentinel blocks the action
     executor.execute.assert_not_called()
+    assert "block" in audit.read_text()


### PR DESCRIPTION
## Summary
- implement `EthicalSentinel` with policy schema validation and audit logging
- add `policies/policy_schema.json` schema
- update unit test for audit log behaviour
- mark Ethical Sentinel task as done

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686d00bc4a10832a96c871977bda0b30