### PR TITLE
Add pip-audit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,27 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.lock
+      - name: Install pip-audit
+        run: pip install pip-audit==2.9.0
+      - name: Run pip-audit
+        run: |
+          pip-audit -r requirements.lock -f json -o pip-audit.json
+      - name: Fail on vulnerabilities
+        run: |
+          python - <<'EOF'
+import json, sys
+with open('pip-audit.json') as f:
+    data = json.load(f)
+count = sum(len(d.get('vulns', [])) for d in data.get('dependencies', []))
+if count:
+    print(f"{count} vulnerabilities found")
+    sys.exit(1)
+EOF
+      - name: Upload pip-audit report
+        uses: actions/upload-artifact@v3
+        with:
+          name: pip-audit-report
+          path: pip-audit.json
       - name: Build Docker images
         run: docker compose -f docker-compose.yml build
       - name: Install pylint

--- a/docs/ci/dependency_updates.md
+++ b/docs/ci/dependency_updates.md
@@ -1,0 +1,23 @@
+# Updating Dependencies When pip-audit Fails
+
+The CI workflow runs `pip-audit` to check `requirements.lock` for known vulnerabilities. If the audit reports medium or higher severity issues, the build will fail.
+
+To resolve a failing audit:
+
+1. **Upgrade the affected packages**
+   ```bash
+   pip install --upgrade <package>
+   ```
+2. **Regenerate the lock file** using [pip-tools](https://pypi.org/project/pip-tools/).
+   ```bash
+   pip install pip-tools
+   pip-compile requirements.txt --output-file requirements.lock
+   ```
+3. **Verify locally** by running:
+   ```bash
+   pip-audit -r requirements.lock
+   ```
+   Ensure no vulnerabilities remain.
+4. Commit the updated `requirements.txt` and `requirements.lock` files.
+
+The next CI run should pass once all vulnerabilities have been addressed.


### PR DESCRIPTION
## Summary
- install `pip-audit` during CI
- fail the build when vulnerabilities are found and upload the report
- document how to update dependencies when `pip-audit` fails

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686d134bb494832abe38ac2d85808e6a