### PR TITLE
Add Bandit static analysis to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,25 @@ EOF
         run: pip install semgrep==1.62.0
       - name: Run Semgrep
         run: semgrep --config auto --error
+      - name: Run Bandit
+        run: |
+          bandit -r core plugins -x tests -f json -o bandit.json
+      - name: Fail on Bandit high-severity findings
+        run: |
+          python - <<'EOF'
+import json, sys
+with open('bandit.json') as f:
+    data = json.load(f)
+highs = [r for r in data.get('results', []) if r.get('issue_severity') == 'HIGH']
+if highs:
+    print(f"{len(highs)} high-severity issues found")
+    sys.exit(1)
+EOF
+      - name: Upload Bandit report
+        uses: actions/upload-artifact@v3
+        with:
+          name: bandit-report
+          path: bandit.json
       - name: Run plugin tests in sandbox
         run: |
           docker run --rm -v $(pwd):/app:ro --network none -w /app python:3.12-slim \

--- a/docs/ci/running_bandit.md
+++ b/docs/ci/running_bandit.md
@@ -1,0 +1,13 @@
+# Running Bandit Locally
+
+The CI workflow uses [Bandit](https://bandit.readthedocs.io) to scan the source code for security issues. To reproduce the scan locally:
+
+1. Install the dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run Bandit from the project root:
+   ```bash
+   bandit -r core plugins -x tests -f json -o bandit.json
+   ```
+3. Review the `bandit.json` report. The CI job fails if any findings with `issue_severity` set to `HIGH` are present.

--- a/requirements.lock
+++ b/requirements.lock
@@ -3,6 +3,7 @@ anyio==4.9.0
 asgiref==3.9.1
 astroid==3.3.10
 attrs==25.3.0
+bandit==1.7.8
 black==25.1.0
 certifi==2025.6.15
 charset-normalizer==3.4.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ jsonschema==4.24.0
 radon==5.1.0
 wily==1.25.0
 pylint==3.3.7
+bandit==1.7.8
 fastapi==0.116.0
 uvicorn==0.35.0
 requests==2.32.4


### PR DESCRIPTION
## Summary
- install `bandit` in CI requirements
- run Bandit during the workflow
- fail CI on high severity findings and upload the report
- document how to run Bandit locally

## Testing
- `pip install -r requirements.lock`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_686d19f58578832abb1486fc19bf9bd7