### PR TITLE
Add plugin sandbox testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,13 @@ EOF
         with:
           name: bandit-report
           path: bandit.json
+      - name: Build plugin sandbox image
+        run: docker build -t plugin-test-sandbox -f plugins/sandbox/Dockerfile .
       - name: Run plugin tests in sandbox
         run: |
-          docker run --rm -v $(pwd):/app:ro --network none -w /app python:3.12-slim \
-            bash -c "pip install -r requirements.lock && pytest tests/test_plugin_security.py"
+          docker run --rm --network none --read-only --tmpfs /tmp \
+            -v $(pwd):/app:ro -w /app plugin-test-sandbox \
+            tests/test_plugin_security.py
       - name: Run tests
         run: |
           pytest --maxfail=1 --disable-warnings -q

--- a/docs/plugins/permissions.md
+++ b/docs/plugins/permissions.md
@@ -30,3 +30,10 @@ The file follows `plugins/policy_schema.json` and maps each plugin ID to the
 permissions it may use. When present, the plugin loader rejects any plugin not
 listed or requesting permissions outside its allowed set. Use the
 `PLUGIN_POLICY_FILE` environment variable to specify an alternate policy path.
+
+## Sandbox Testing
+
+All plugins are executed in a minimal Docker sandbox during CI. The sandbox image
+is defined in [`plugins/sandbox/Dockerfile`](../../plugins/sandbox/Dockerfile)
+and mounted read-only with no network access. See
+[`sandbox.md`](sandbox.md) for details.

--- a/docs/plugins/sandbox.md
+++ b/docs/plugins/sandbox.md
@@ -1,0 +1,16 @@
+# Plugin Sandbox Environment
+
+The CI pipeline executes plugin unit tests inside a restricted Docker container to
+catch malicious behavior early. The sandbox is defined by
+`plugins/sandbox/Dockerfile` and uses a minimal Python base image.
+
+Key properties:
+
+- Dependencies from `requirements.lock` are installed during the build.
+- A non‑root `sandbox` user runs all tests.
+- The container itself has no network access and a read‑only file system when run
+  in CI (`--network none` and `--read-only`).
+- Temporary write access is provided only through an in-memory `/tmp` volume.
+
+If a plugin attempts to access the network or modify the repository, the tests
+fail and the pipeline aborts.

--- a/plugins/sandbox/Dockerfile
+++ b/plugins/sandbox/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.12-slim
+
+# Create non-root user
+RUN useradd -m sandbox
+
+# Install project dependencies
+COPY requirements.lock /tmp/requirements.lock
+RUN pip install --no-cache-dir -r /tmp/requirements.lock && rm /tmp/requirements.lock
+
+WORKDIR /app
+USER sandbox
+ENTRYPOINT ["pytest"]


### PR DESCRIPTION
## Summary
- build minimal plugin sandbox image
- run plugin unit tests inside the sandbox during CI
- document how the plugin sandbox works

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686d1d70b374832aa7fcdb346d81fb13