### PR TITLE
Add cosign signing step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,11 @@ EOF
       - name: Run tests
         run: |
           pytest --maxfail=1 --disable-warnings -q
+      - name: Install cosign
+        run: |
+          curl -L https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64 -o cosign
+          chmod +x cosign
+          sudo mv cosign /usr/local/bin/cosign
       - name: Package example plugin
         run: python scripts/package_plugin.py plugins/example_plugin
       - name: Sign plugin artifact

--- a/docs/plugins/permissions.md
+++ b/docs/plugins/permissions.md
@@ -23,6 +23,18 @@ python scripts/package_plugin.py plugins/example_plugin
 The script creates `dist/<id>-<version>.zip` containing `manifest.json` and all
 Python source files while excluding compiled artifacts.
 
+## Signing Plugins
+
+The CI pipeline installs [cosign](https://docs.sigstore.dev/cosign/overview/) and
+signs each packaged plugin. The private key is provided via the `COSIGN_KEY`
+secret, and the signature file (`.sig`) is uploaded alongside the plugin
+archive. You can verify a signature locally using your public key:
+
+```bash
+cosign verify-blob --key cosign.pub dist/example-0.1.0.zip \
+  --signature dist/example-0.1.0.zip.sig
+```
+
 ## Policy Enforcement
 
 Administrators may define `plugins/policy.json` to whitelist approved plugins.


### PR DESCRIPTION
## Summary
- install `cosign` in CI
- sign plugin artifacts and keep `.sig` files
- document the signing process for plugins

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686d295f2e98832ab63c1a4f6fb59fa4