### PR TITLE
Refactor orchestrator state handling

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,6 +4,7 @@
 
 ### Orchestrator
 Coordinates the main control loop for the self-improving system. It initializes with components like `Planner`, `Executor`, `Reflector`, and `Memory`. The `run` method orchestrates the primary workflow: loading tasks from persistence (e.g., `tasks.yml`) using `Memory`, invoking the `Reflector` to analyze the codebase and potentially generate new tasks (which are then saved back via `Memory`), and then entering a loop. In this loop, it uses the `Planner` to decide the next task, marks the task as "in_progress" (saving state), executes it using the `Executor`, and finally marks it as "done" (again, saving state). The loop continues until the `Planner` determines no more actionable tasks are available.
+State management is delegated to helper methods (`_set_status`, `_save_tasks` and `_audit_and_extend`) which handle persistence and auditing. This keeps `_execute_task` concise.
 
 ```python
 class Orchestrator:

--- a/tasks.yml
+++ b/tasks.yml
@@ -47,7 +47,7 @@
   description: Refactor core/orchestrator.py complexity 13
   dependencies: []
   priority: 3
-  status: pending
+  status: done
   area: core
   actionable_steps: []
   acceptance_criteria: []

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -36,12 +36,12 @@ def test_policy_loading_and_blocking(tmp_path: Path):
     orch = Orchestrator(planner, executor, reflector, memory, auditor, sentinel=sentinel)
 
     orch.logger = MagicMock()
-    message = "Orchestrator: Task 'block' blocked by Ethical Sentinel."
-
     orch.run("tasks.yml")
 
     assert sentinel.blocked_actions == {"block"}
-    orch.logger.info.assert_any_call(message)
+    orch.logger.info.assert_any_call(
+        "Orchestrator: Task '%s' blocked by Ethical Sentinel.", "block"
+    )
     # Executor should not be called because sentinel blocks the action
     executor.execute.assert_not_called()
     assert "block" in audit.read_text()


### PR DESCRIPTION
## Summary
- break state management in `core/orchestrator.py` into helper methods
- adjust sentinel test for new logging call
- mark orchestrator refactor task done
- document helper methods in `ARCHITECTURE.md`

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686d30931a9c832aa5f4704196da784a