### PR TITLE
Add research outlines and link from vision

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -23,3 +23,12 @@ The Ethical Sentinel guards against harmful behavior. It assesses new ideas and 
 - Document decision mappings in the Intent Mapper.
 - Prototype a small Creative Synthesizer experiment.
 - Define ethical review criteria for the Ethical Sentinel.
+
+## Research Outlines
+- [Prioritization](research/RB-003_Vision_Engine_Prioritization.md)
+- [Cross-Language Design](research/RB-004_Cross_Language_Design.md)
+- [Metrics & Observability](research/RB-005_Metrics_and_Observability.md)
+- [Plugin Governance](research/RB-006_Governance.md)
+- [Ethical Sentinel](research/RB-007_Ethical_Sentinel.md)
+- [Self-Improvement](research/RB-008_Self_Improvement.md)
+- [Community Mapping](research/RB-009_Community_Ecosystem_Mapping.md)

--- a/research/RB-003_Vision_Engine_Prioritization.md
+++ b/research/RB-003_Vision_Engine_Prioritization.md
@@ -1,0 +1,18 @@
+# Research Brief RB-003: Vision Engine Prioritization
+
+This outline surveys how modern software projects prioritize work and how those ideas could shape the Vision Engine.
+
+## Literature Summary
+- **WSJF (Weighted Shortest Job First)** from the Scaled Agile Framework ranks work by dividing business value by job size.
+- **Reinforcement learning for scheduling** (e.g., Jaderberg 2017) explores agents that adapt priorities based on observed reward.
+- **Multi-criteria decision analysis** methods like AHP compare qualitative factors when quantitative data is sparse.
+
+## Open Questions
+- How can WSJF heuristics seed an RL agent without locking in bias?
+- What metrics best capture long-term architectural value versus short-term velocity?
+- Can feedback from the Reflector Core autonomously refine prioritization weights?
+
+## Implementation Acceptance Criteria
+- Future prioritization tasks should implement a baseline WSJF algorithm.
+- RL models must ingest Reflector metrics to adjust ranking dynamically.
+- Tests should demonstrate improved backlog ordering against historical baselines.

--- a/research/RB-004_Cross_Language_Design.md
+++ b/research/RB-004_Cross_Language_Design.md
@@ -1,0 +1,18 @@
+# Research Brief RB-004: Cross-Language Design
+
+This outline explores approaches for mixing programming languages across the system while maintaining maintainability.
+
+## Literature Summary
+- **Polyglot microservices** leverage language-specific strengths; Martin Fowler notes benefits of autonomy and scalability.
+- **FFI and gRPC** allow safe bindings between Rust, Python, and Node.js with minimal overhead.
+- **Message queue protocols** such as NATS or Kafka decouple services for asynchronous coordination.
+
+## Open Questions
+- Which components benefit most from Rust's performance versus Python's flexibility?
+- How can we enforce type safety across language boundaries?
+- What tooling is required to manage multi-language builds in CI?
+
+## Implementation Acceptance Criteria
+- Adopt a microservice or plugin interface allowing Rust/Node services to integrate via gRPC or queues.
+- Provide build scripts that compile foreign code and run tests in CI.
+- Demonstrate one cross-language module exchanging data with the existing Python core.

--- a/research/RB-005_Metrics_and_Observability.md
+++ b/research/RB-005_Metrics_and_Observability.md
@@ -1,0 +1,18 @@
+# Research Brief RB-005: Metrics and Observability
+
+Capturing rich telemetry is essential for self-evolution. This outline consolidates best practices for metrics and traces.
+
+## Literature Summary
+- **OpenTelemetry** defines a vendor-neutral standard for metrics, logs, and traces.
+- **Prometheus and Grafana** provide storage and visualization widely used in cloud-native setups.
+- **Adaptive monitoring** approaches stream metrics back to reinforcement learning agents for continuous tuning.
+
+## Open Questions
+- Which metrics truly correlate with developer productivity and code health?
+- How can we minimize overhead while capturing fine-grained traces?
+- Can observability data directly influence planning decisions via the Reflector Core?
+
+## Implementation Acceptance Criteria
+- Instrument core components using OpenTelemetry APIs.
+- Store metrics in Prometheus and expose Grafana dashboards as code.
+- Prove feedback into the Reflector by feeding metrics to learning algorithms.

--- a/research/RB-006_Governance.md
+++ b/research/RB-006_Governance.md
@@ -1,0 +1,18 @@
+# Research Brief RB-006: Plugin Governance
+
+Governance ensures plugins remain secure and compatible. This outline reviews governance models and compliance tools.
+
+## Literature Summary
+- **Open-source package governance** practices emphasize signed releases and community vetting.
+- **Supply chain security frameworks** like SLSA outline provenance requirements for build pipelines.
+- **Marketplace policy** examples from browser extension stores show how automated scans and manual review coexist.
+
+## Open Questions
+- What minimal review process keeps plugins safe without slowing innovation?
+- How should we manage version compatibility and deprecation across plugins?
+- Could a reputation system incentivize high-quality contributions?
+
+## Implementation Acceptance Criteria
+- CI must run static analysis and vulnerability scans on all plugin submissions.
+- Signed artifacts should be stored alongside plugin metadata.
+- Governance documentation should describe review steps and escalation paths.

--- a/research/RB-007_Ethical_Sentinel.md
+++ b/research/RB-007_Ethical_Sentinel.md
@@ -1,0 +1,18 @@
+# Research Brief RB-007: Ethical Sentinel Policies
+
+This outline surveys ethical frameworks relevant to autonomous agents and how they inform the Ethical Sentinel.
+
+## Literature Summary
+- **IEEE Ethically Aligned Design** offers guidelines for transparency and human well-being.
+- **EU AI Act and OECD principles** outline requirements for accountability and risk management.
+- **AI alignment research** highlights pitfalls of goal misspecification and unintended behavior.
+
+## Open Questions
+- How can policy checks be automated without overblocking legitimate experimentation?
+- What escalation paths exist when the Sentinel identifies potential harm?
+- How do we balance user privacy with observability requirements?
+
+## Implementation Acceptance Criteria
+- Sentinel modules should reference a documented policy catalog derived from this research.
+- Policy checks need unit tests covering allowed and disallowed behaviors.
+- Alerting and override mechanisms should be documented for human review.

--- a/research/RB-008_Self_Improvement.md
+++ b/research/RB-008_Self_Improvement.md
@@ -1,0 +1,18 @@
+# Research Brief RB-008: Self-Improvement Optimization
+
+Continuous self-improvement is a key differentiator of AI-SWA. This outline surveys approaches for automated learning loops.
+
+## Literature Summary
+- **Proximal Policy Optimization (PPO)** is a stable reinforcement learning algorithm for training code-generating agents.
+- **Evolutionary strategies** can explore large policy spaces without gradient information.
+- **Self-play and curriculum learning** gradually increase difficulty to improve sample efficiency.
+
+## Open Questions
+- How do we design reward functions that encourage maintainable code, not just passing tests?
+- Could experience replay stabilize learning when tasks are sparse?
+- What safeguards prevent catastrophic forgetting during continual updates?
+
+## Implementation Acceptance Criteria
+- Implement a replay buffer and curriculum generator informed by this research.
+- Evaluate agents against historical commits to measure improvement.
+- Provide rollback mechanisms if performance degrades.

--- a/research/RB-009_Community_Ecosystem_Mapping.md
+++ b/research/RB-009_Community_Ecosystem_Mapping.md
@@ -1,0 +1,18 @@
+# Research Brief RB-009: Community and Ecosystem Mapping
+
+Understanding the broader ecosystem helps position AI-SWA in the open-source world and identify collaborators.
+
+## Literature Summary
+- **Open-source ecosystem studies** highlight the role of contributor networks in project success.
+- **Commercial platform surveys** (e.g., Hugging Face, GitHub Copilot) show trends in hosted agent services.
+- **Community mapping tools** like CHAOSS metrics evaluate project health and engagement.
+
+## Open Questions
+- Which adjacent projects could merge or integrate with AI-SWA?
+- How can we attract contributors while maintaining clear governance?
+- What outreach channels best reach developer communities interested in autonomous agents?
+
+## Implementation Acceptance Criteria
+- Produce a living ecosystem map listing strategic projects and communities.
+- Track engagement metrics using CHAOSS or similar frameworks.
+- Document contribution guidelines that align with governance research.

--- a/tasks.yml
+++ b/tasks.yml
@@ -108,10 +108,16 @@
   dependencies:
   - 53
   priority: 3
-  status: pending
+  status: done
   area: research
-  actionable_steps: []
-  acceptance_criteria: []
+  actionable_steps:
+  - Summarize literature on WSJF and RL-based prioritization
+  - Capture open questions for hybrid scheduling
+  - Create research/RB-003_Vision_Engine_Prioritization.md with implementation criteria
+  - Link outline from VISION.md
+  acceptance_criteria:
+  - research/RB-003_Vision_Engine_Prioritization.md outlines literature and questions
+  - VISION.md references RB-003
   assigned_to: null
   epic: Legacy
 - id: 55
@@ -119,10 +125,16 @@
   dependencies:
   - 53
   priority: 3
-  status: pending
+  status: done
   area: research
-  actionable_steps: []
-  acceptance_criteria: []
+  actionable_steps:
+  - Review microservice patterns for Rust and Node interoperability
+  - Document FFI and message queue strategies
+  - Create research/RB-004_Cross_Language_Design.md with future criteria
+  - Link outline from VISION.md
+  acceptance_criteria:
+  - research/RB-004_Cross_Language_Design.md summarizes approaches
+  - VISION.md references RB-004
   assigned_to: null
   epic: Legacy
 - id: 56
@@ -130,10 +142,16 @@
   dependencies:
   - 53
   priority: 3
-  status: pending
+  status: done
   area: research
-  actionable_steps: []
-  acceptance_criteria: []
+  actionable_steps:
+  - Survey OpenTelemetry, Prometheus, Grafana integration
+  - Identify gaps in current metrics collection
+  - Create research/RB-005_Metrics_and_Observability.md with implementation criteria
+  - Link outline from VISION.md
+  acceptance_criteria:
+  - research/RB-005_Metrics_and_Observability.md covers literature and questions
+  - VISION.md references RB-005
   assigned_to: null
   epic: Legacy
 - id: 57
@@ -141,10 +159,16 @@
   dependencies:
   - 53
   priority: 3
-  status: pending
+  status: done
   area: research
-  actionable_steps: []
-  acceptance_criteria: []
+  actionable_steps:
+  - Analyze plugin marketplace governance models
+  - Document security and compliance requirements
+  - Create research/RB-006_Governance.md with future criteria
+  - Link outline from VISION.md
+  acceptance_criteria:
+  - research/RB-006_Governance.md lists policies and open issues
+  - VISION.md references RB-006
   assigned_to: null
   epic: Legacy
 - id: 58
@@ -152,10 +176,16 @@
   dependencies:
   - 53
   priority: 3
-  status: pending
+  status: done
   area: research
-  actionable_steps: []
-  acceptance_criteria: []
+  actionable_steps:
+  - Review AI ethics frameworks and safety literature
+  - Capture unresolved concerns for autonomous agents
+  - Create research/RB-007_Ethical_Sentinel.md with implementation criteria
+  - Link outline from VISION.md
+  acceptance_criteria:
+  - research/RB-007_Ethical_Sentinel.md summarizes frameworks and questions
+  - VISION.md references RB-007
   assigned_to: null
   epic: Legacy
 - id: 59
@@ -163,10 +193,16 @@
   dependencies:
   - 53
   priority: 3
-  status: pending
+  status: done
   area: research
-  actionable_steps: []
-  acceptance_criteria: []
+  actionable_steps:
+  - Examine RL and evolutionary algorithms for autonomous coding
+  - Note challenges with reward shaping and stability
+  - Create research/RB-008_Self_Improvement.md with future criteria
+  - Link outline from VISION.md
+  acceptance_criteria:
+  - research/RB-008_Self_Improvement.md covers literature and questions
+  - VISION.md references RB-008
   assigned_to: null
   epic: Legacy
 - id: 60
@@ -174,10 +210,16 @@
   dependencies:
   - 53
   priority: 3
-  status: pending
+  status: done
   area: research
-  actionable_steps: []
-  acceptance_criteria: []
+  actionable_steps:
+  - Survey open-source agent frameworks and commercial platforms
+  - Identify opportunities for partnerships and outreach
+  - Create research/RB-009_Community_Ecosystem_Mapping.md with future criteria
+  - Link outline from VISION.md
+  acceptance_criteria:
+  - research/RB-009_Community_Ecosystem_Mapping.md summarizes platforms and gaps
+  - VISION.md references RB-009
   assigned_to: null
   epic: Legacy
 - id: 61


### PR DESCRIPTION
## Summary
- create research briefs covering prioritization, cross-language design, metrics, plugin governance, ethics, self-improvement, and community mapping
- link briefs from `VISION.md`
- mark outline tasks as done with details and acceptance criteria

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'grpc')*

------
https://chatgpt.com/codex/tasks/task_e_686d40d91920832a8ecd41c3b1e1f420