### PR TITLE
Add strategic roadmap tasks

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -1106,3 +1106,125 @@
     - CI workflow completes without errors on main branch
   assigned_to: null
   epic: Build and Test
+
+- id: 150
+  task_id: VE-001
+  title: Implement Hybrid Vision Engine with WSJF and RL
+  description: Develop and integrate the hybrid prioritization engine as specified in the research documents.
+  area: vision
+  actionable_steps:
+    - Implement a standardized WSJF calculator as a baseline heuristic.
+    - Develop an RL-based Hyper-heuristic (RL-HH) agent for prioritization refinement.
+    - Integrate the RL agent to run in shadow mode initially, logging its decisions for analysis against the WSJF baseline.
+  dependencies: [134, 139]
+  acceptance_criteria:
+    - The Vision Engine produces a transparent, defensible ranking using WSJF scores.
+    - The RL agent's suggested prioritizations are logged for offline evaluation.
+  priority: 1
+  status: pending
+  epic: Vision Engine
+
+- id: 151
+  task_id: ARCH-001
+  title: Evolve to Polyglot Architecture - Phase 1 (Rust Integration)
+  description: Begin the phased transition to a polyglot microservices architecture by integrating Rust for performance-critical components.
+  area: core
+  actionable_steps:
+    - Identify computationally intensive bottlenecks in the Python codebase using profiling tools.
+    - Rewrite the identified modules in Rust.
+    - Integrate the new Rust modules into the Python application using PyO3.
+    - Benchmark performance before and after to validate improvements.
+  dependencies: [82]
+  acceptance_criteria:
+    - At least one performance-critical Python module is successfully replaced with a Rust equivalent.
+    - Integration tests pass, and performance metrics show measurable improvement.
+  priority: 2
+  status: pending
+  epic: Architecture
+
+- id: 152
+  task_id: OBS-002
+  title: Implement "OPG" Observability Stack
+  description: Deploy and configure the OpenTelemetry, Prometheus, and Grafana stack to provide the sensory feedback for the self-improvement loop.
+  area: observability
+  actionable_steps:
+    - Deploy Prometheus and Grafana instances.
+    - Instrument all services with the OpenTelemetry SDK.
+    - Configure the OTel Collector to send metrics to Prometheus.
+    - Create initial Grafana dashboards for key system health metrics, defined as code.
+  dependencies: [125, 130]
+  acceptance_criteria:
+    - Metrics from all core services are visible in a Grafana dashboard.
+    - The observability stack is deployed via an infrastructure-as-code process.
+  priority: 1
+  status: pending
+  epic: Observability
+
+- id: 153
+  task_id: SEC-002
+  title: Implement Plugin Certification Pipeline
+  description: Build the automated CI/CD pipeline for vetting and signing third-party plugins.
+  area: security
+  actionable_steps:
+    - Enhance the existing CI pipeline to include mandatory SCA, SAST, and secret scanning stages.
+    - Implement a sandboxed environment for dynamic behavioral testing of plugins.
+    - Integrate a dual-signing process where the pipeline cryptographically signs certified plugins.
+  dependencies: [135, 140, 143, 144, 145, 146]
+  acceptance_criteria:
+    - The CI pipeline automatically rejects plugins with high-severity vulnerabilities or license compliance issues.
+    - Successfully vetted plugins are cryptographically signed and published to a secure registry.
+  priority: 1
+  status: pending
+  epic: Ecosystem
+
+- id: 154
+  task_id: ETH-002
+  title: Operationalize Ethical Sentinel Policy Framework
+  description: Implement the policy catalog and human-in-the-loop governance for the Ethical Sentinel.
+  area: governance
+  actionable_steps:
+    - Establish the hybrid AI Ethics Board with internal and external reviewers.
+    - Implement the detailed Ethical Policy Template as a required, machine-readable artifact for all new modules.
+    - Develop the two-stage AI Incident Response Plan (AI-IRP) with automated containment and human escalation paths.
+  dependencies: [136, 141]
+  acceptance_criteria:
+    - No new module can be deployed without a completed and approved Ethical Policy document.
+    - The Sentinel can demonstrate automated containment of a simulated high-severity incident.
+  priority: 2
+  status: pending
+  epic: Governance
+
+- id: 155
+  task_id: REF-003
+  title: Implement Two-Speed Reflector Core
+  description: Develop the dual-loop architecture for the Reflector Core's self-improvement capability.
+  area: reflector
+  actionable_steps:
+    - Implement the "inner loop" using a PPO-based agent for online policy refinement.
+    - Develop the "outer loop" using an offline Evolutionary Strategy (ES) to optimize the architecture of the PPO agent itself.
+    - Create a high-fidelity simulation environment for the outer loop to evaluate candidate agent architectures.
+  dependencies: [137, 142, 66, 67, 70]
+  acceptance_criteria:
+    - The inner loop agent can autonomously generate and apply refactoring tasks.
+    - The outer loop can successfully execute an evolutionary cycle and produce a measurably improved inner loop agent.
+  priority: 2
+  status: pending
+  epic: Reflector Outer Loop
+
+- id: 156
+  task_id: COM-001
+  title: Establish Community Governance and Outreach - Phase 1
+  description: Implement the foundational elements of the community growth blueprint.
+  area: community
+  actionable_steps:
+    - Select a unique, searchable project name to resolve brand ambiguity.
+    - Publish core governance documents: GOVERNANCE.md (adopting a Liberal Contribution model) and a clear CONTRIBUTING.md.
+    - Set up a community health dashboard using CHAOSS metrics, tracking Time to First Response and Contributor Absence Factor.
+  dependencies: [91]
+  acceptance_criteria:
+    - The project is renamed and has a clear mission statement in its README.
+    - Core governance and contribution documents are published.
+    - A public community health dashboard is available.
+  priority: 1
+  status: pending
+  epic: Community


### PR DESCRIPTION
## Summary
- add tasks 150-156 implementing roadmap proposals for Vision Engine, architecture, observability, security, governance, reflector, and community

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_686d59f08f14832a97c3d24df2cf00f8