### PR TITLE
Implement Researcher semantic search and observer dashboard

### DIFF
--- a/core/researcher.py
+++ b/core/researcher.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections import Counter
+from pathlib import Path
+from typing import List, Tuple
+
+from .log_utils import configure_logging
+
+
+class _VectorStore:
+    """In-memory vector store using simple term frequency vectors."""
+
+    def __init__(self) -> None:
+        self.docs: List[str] = []
+        self.vectors: List[Counter] = []
+
+    def add_document(self, name: str, text: str) -> None:
+        tokens = self._tokenize(text)
+        self.docs.append(name)
+        self.vectors.append(Counter(tokens))
+
+    def search(self, query: str, top_k: int = 5) -> List[Tuple[str, float]]:
+        q_vec = Counter(self._tokenize(query))
+        results = []
+        for name, vec in zip(self.docs, self.vectors):
+            sim = self._cosine_similarity(q_vec, vec)
+            results.append((name, sim))
+        results.sort(key=lambda x: x[1], reverse=True)
+        return results[:top_k]
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _tokenize(text: str) -> List[str]:
+        return re.findall(r"\w+", text.lower())
+
+    @staticmethod
+    def _cosine_similarity(v1: Counter, v2: Counter) -> float:
+        if not v1 or not v2:
+            return 0.0
+        common = set(v1) & set(v2)
+        dot = sum(v1[w] * v2[w] for w in common)
+        norm1 = math.sqrt(sum(v * v for v in v1.values()))
+        norm2 = math.sqrt(sum(v * v for v in v2.values()))
+        if not norm1 or not norm2:
+            return 0.0
+        return dot / (norm1 * norm2)
+
+
+class Researcher:
+    """Provide semantic search over local research documents."""
+
+    def __init__(self, docs_path: Path | str = "research") -> None:
+        configure_logging()
+        self.logger = logging.getLogger(__name__)
+        self.docs_path = Path(docs_path)
+        self.store = _VectorStore()
+        self._index_documents()
+
+    # ------------------------------------------------------------------
+    def _index_documents(self) -> None:
+        if not self.docs_path.exists():
+            self.logger.warning("Docs path %s not found", self.docs_path)
+            return
+        for p in self.docs_path.glob("*.md"):
+            try:
+                text = p.read_text(encoding="utf-8")
+            except Exception as exc:  # pragma: no cover - file errors
+                self.logger.warning("Failed to read %s: %s", p, exc)
+                continue
+            self.store.add_document(p.name, text)
+        self.logger.info("Indexed %d documents", len(self.store.docs))
+
+    # ------------------------------------------------------------------
+    def search(self, query: str, top_k: int = 5) -> List[Tuple[str, float]]:
+        """Return top matching document names and similarity scores."""
+        return self.store.search(query, top_k)

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,15 @@
+# Observability Setup
+
+AI-SWA services expose Prometheus metrics for local debugging. Two Grafana dashboards are provided:
+
+- **improvement-dashboard.json** – tracks task throughput.
+- **observer-dashboard.json** – monitors worker CPU, memory and aggregate task metrics.
+
+## Usage
+
+1. Run the stack with `docker-compose up` or start the services manually.
+2. Execute `python scripts/update_dashboards.py` to regenerate the dashboard JSON files.
+3. Import the JSON files into Grafana and set Prometheus as the data source.
+
+Running the update script ensures the dashboards stay current during local runs.
+

--- a/grafana/observer_dashboard.py
+++ b/grafana/observer_dashboard.py
@@ -1,0 +1,36 @@
+from grafanalib.core import Dashboard, Graph, Row, Target
+from grafanalib.prometheus import PromQL
+
+OBSERVER_DASHBOARD = Dashboard(
+    title="Observer Metrics",
+    rows=[
+        Row(panels=[
+            Graph(
+                title="Worker CPU Usage",
+                dataSource="Prometheus",
+                targets=[Target(expr="process_cpu_seconds_total", legendFormat="cpu")],
+            ),
+            Graph(
+                title="Worker Memory",
+                dataSource="Prometheus",
+                targets=[Target(expr="process_resident_memory_bytes", legendFormat="mem")],
+            ),
+        ]),
+        Row(panels=[
+            Graph(
+                title="Tasks Executed",
+                dataSource="Prometheus",
+                targets=[Target(expr="tasks_executed_total", legendFormat="executed")],
+            ),
+            Graph(
+                title="Orchestrator Runs",
+                dataSource="Prometheus",
+                targets=[Target(expr="orchestrator_runs_total", legendFormat="runs")],
+            ),
+        ]),
+    ],
+).auto_panel_ids()
+
+if __name__ == "__main__":
+    import json
+    print(json.dumps(OBSERVER_DASHBOARD.to_json_data(), indent=2))

--- a/scripts/update_dashboards.py
+++ b/scripts/update_dashboards.py
@@ -1,0 +1,22 @@
+"""Generate Grafana dashboard JSON files."""
+
+from pathlib import Path
+import json
+
+from grafana.dashboard import DASHBOARD
+from grafana.observer_dashboard import OBSERVER_DASHBOARD
+
+
+def write_dashboard(obj, path: Path) -> None:
+    path.write_text(json.dumps(obj.to_json_data(), indent=2))
+
+
+def main() -> None:
+    write_dashboard(DASHBOARD, Path("improvement-dashboard.json"))
+    write_dashboard(OBSERVER_DASHBOARD, Path("observer-dashboard.json"))
+    print("Dashboards updated")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tasks.yml
+++ b/tasks.yml
@@ -550,7 +550,7 @@
   description: Semantic search for Researcher agent
   dependencies: []
   priority: 3
-  status: pending
+  status: done
   area: research
   actionable_steps: []
   acceptance_criteria: []
@@ -560,7 +560,7 @@
   description: Observer metrics dashboard
   dependencies: []
   priority: 3
-  status: pending
+  status: done
   area: observability
   actionable_steps: []
   acceptance_criteria: []

--- a/tests/test_researcher.py
+++ b/tests/test_researcher.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from core.researcher import Researcher
+
+
+def test_search_ranks_relevant_docs(tmp_path: Path) -> None:
+    d1 = tmp_path / "doc1.md"
+    d2 = tmp_path / "doc2.md"
+    d1.write_text("machine learning improves search")
+    d2.write_text("orchestrator handles tasks")
+
+    researcher = Researcher(docs_path=tmp_path)
+    results = researcher.search("learning search", top_k=1)
+    assert results and results[0][0] == "doc1.md"
+


### PR DESCRIPTION
## Summary
- implement a simple semantic search capability for the Researcher agent
- add Grafana dashboard for Observer metrics and script to generate dashboards
- document observability instructions
- mark related tasks as done
- add tests for the new Researcher

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686dbcb01d24832aa8eae68f405a9104