### PR TITLE
Add review notes for queue tests and RL prioritization

### DIFF
--- a/docs/reviews/task_138_queue_review.md
+++ b/docs/reviews/task_138_queue_review.md
@@ -1,0 +1,16 @@
+# Task 138 Broker Queue Review
+
+We inspected the integration tests covering the microservice workflow for the broker and worker components.
+
+## Findings
+
+- `tests/test_worker_broker_flow.py` starts a broker process and verifies a worker posts results back via `/tasks/{id}/result`.
+- `tests/test_worker_concurrency.py` launches multiple workers and confirms each task fetched from `/tasks/next` is processed exactly once.
+- `tests/test_worker_async_loop.py` checks the worker's async loop with configurable concurrency.
+- `tests/test_docker_compose_workflow.py` and `tests/e2e/test_compose_pipeline.py` run the full Docker Compose stack and execute a sample task end to end.
+
+## Gaps
+
+- No tests exercise the `api_gateway` service or `orchestrator_api` start/stop endpoints.
+- The Node `io-service` is only pinged for health but lacks dedicated tests.
+- Compose tests cover a single task and do not stress queue ordering or failure recovery.

--- a/docs/reviews/task_139_rl_review.md
+++ b/docs/reviews/task_139_rl_review.md
@@ -1,0 +1,14 @@
+# Task 139 RL Prioritization Review
+
+The Vision Engine includes a reinforcement-learning agent used to refine WSJF task rankings.
+
+## Findings
+
+- `tests/test_rl_vs_wsjf_integration.py` demonstrates that an RL agent with full authority can change the ordering produced by WSJF alone.
+- `tests/test_rl_training.py` validates that training metrics are collected and persisted for offline analysis.
+- Details of the experiment are documented in `docs/research/RL_vs_WSJF_Test_Report.md`.
+
+## Gaps
+
+- No integration test covers mixed-authority modes where RL suggestions only partially override WSJF.
+- The RL agent's `update_authority` logic lacks direct test coverage.


### PR DESCRIPTION
## Summary
- document audit of microservice queue integration tests
- record findings from RL prioritization review

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: No module named `vision.cli`)*

------
https://chatgpt.com/codex/tasks/task_e_686dc51f6cd4832aab004fdfa4f7c753