### PR TITLE
Update tasks with multi-agent research plan

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -1228,3 +1228,586 @@
   priority: 1
   status: pending
   epic: Community
+- id: 157
+  task_id: OBS-01
+  title: Deploy Core OPG Stack
+  description: Deploy and configure the OpenTelemetry, Prometheus, and Grafana stack.
+  area: observability
+  actionable_steps:
+    - Provision Prometheus and Grafana using infrastructure-as-code.
+    - Deploy OpenTelemetry Collectors receiving OTLP data from services.
+    - Configure Collectors to export metrics to Prometheus.
+    - Establish TLS communication between all observability components.
+  dependencies: []
+  acceptance_criteria:
+    - Prometheus successfully scrapes metrics from the collectors.
+    - Grafana is configured with Prometheus as a data source.
+    - All observability components expose their own health metrics.
+  priority: 1
+  status: pending
+  epic: Observability
+
+- id: 158
+  task_id: OBS-02
+  title: Instrument Core Services with OpenTelemetry
+  description: Emit essential telemetry from all core services.
+  area: observability
+  actionable_steps:
+    - Integrate the OpenTelemetry SDK in each service.
+    - Enable auto-instrumentation for common frameworks.
+    - Initialize the SDK at application startup.
+    - Export OTLP data to the deployed collectors.
+  dependencies: [157]
+  acceptance_criteria:
+    - Traces and metrics from all services reach the collectors.
+    - CPU, memory, and request metrics are available in Prometheus.
+  priority: 1
+  status: pending
+  epic: Observability
+
+- id: 159
+  task_id: OBS-03
+  title: Establish GitOps Workflow for Dashboards
+  description: Manage Grafana dashboards declaratively via Git.
+  area: observability
+  actionable_steps:
+    - Implement a declarative tool for Grafana resources.
+    - Store dashboard definitions in a dedicated Git repository.
+    - Create a CI/CD pipeline that applies changes automatically.
+    - Build initial dashboards for basic service health.
+  dependencies: [157]
+  acceptance_criteria:
+    - Editing a dashboard JSON in Git updates Grafana automatically.
+    - Grafana dashboards and data sources are fully declarative.
+  priority: 2
+  status: pending
+  epic: Observability
+
+- id: 160
+  task_id: MEAS-01
+  title: Implement DORA Metrics Collection
+  description: Gather data required to calculate the four key DORA metrics.
+  area: metrics
+  actionable_steps:
+    - Instrument the CI/CD pipeline to count successful deployments.
+    - Build an ETL process to derive lead time for changes.
+    - Track deployments causing failures to compute change failure rate.
+    - Record incident durations to measure mean time to restore.
+  dependencies: [157, 158]
+  acceptance_criteria:
+    - All four DORA metrics are stored in Prometheus.
+    - A Grafana dashboard visualizes the DORA metrics over time.
+  priority: 2
+  status: pending
+  epic: Metrics
+
+- id: 161
+  task_id: MEAS-02
+  title: Implement SPACE Metrics and Guardrails
+  description: Add developer productivity and well-being metrics.
+  area: metrics
+  actionable_steps:
+    - Track p95 PR review-to-merge time from the Git provider API.
+    - Calculate a p90 change complexity score for each pull request.
+    - Deploy a quarterly survey to measure developer satisfaction.
+    - Create a dashboard combining DORA and SPACE metrics.
+  dependencies: [160]
+  acceptance_criteria:
+    - Key SLIs from the metrics catalog are implemented.
+    - The Developer Productivity & Health dashboard is authoritative.
+  priority: 2
+  status: pending
+  epic: Metrics
+
+- id: 162
+  task_id: OPT-01
+  title: Implement Multi-Stage Hybrid Sampling Strategy
+  description: Reduce telemetry volume while keeping critical traces.
+  area: observability
+  actionable_steps:
+    - Apply TraceIDRatioBased sampling in all services.
+    - Configure the collector tail-sampling processor policies.
+    - Preserve all error traces and high-latency traces.
+    - Sample a small fraction of remaining traffic by default.
+  dependencies: [157, 158]
+  acceptance_criteria:
+    - Trace volume is significantly reduced.
+    - Error and high-latency traces are always retained.
+  priority: 3
+  status: pending
+  epic: Observability
+
+- id: 163
+  task_id: REF-01
+  title: Develop High-Fidelity Simulation Environment
+  description: Build a simulation of the AI-SWA production environment.
+  area: reflector
+  actionable_steps:
+    - Model key services, databases, and load balancers.
+    - Ingest real workload patterns to mirror production behavior.
+    - Expose observability data and the same action space as production.
+  dependencies: []
+  acceptance_criteria:
+    - The simulation reproduces known production incidents.
+    - The RL agent can use the same state-action-reward model.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+
+- id: 164
+  task_id: REF-02
+  title: Implement Initial RL Agent with Imitation Learning
+  description: Create the first Reflector Core agent for resource allocation.
+  area: reflector
+  actionable_steps:
+    - Define the state, action, and reward schema.
+    - Collect historical scaling decisions from human operators.
+    - Pre-train the agent using behavioral cloning.
+    - Continue training with PPO in the simulation environment.
+  dependencies: [163]
+  acceptance_criteria:
+    - The agent demonstrates baseline competence in simulation.
+    - After RL training, the agent outperforms the human baseline.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+
+- id: 165
+  task_id: REF-03
+  title: Deploy Reflector Core in Shadow Mode
+  description: Validate the agent in production without executing actions.
+  area: reflector
+  actionable_steps:
+    - Connect the agent to live observability data.
+    - Log intended actions instead of performing them.
+    - Establish human review of the logged decisions.
+  dependencies: [164]
+  acceptance_criteria:
+    - The agent runs continuously without causing issues.
+    - Logged decisions are appropriate in at least 95% of cases.
+    - The system is ready for automated actions.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 166
+  task_id: P2-T1
+  title: Develop Data Integrations
+  description: Integrate external systems to collect data for DORA and SPACE metrics.
+  area: metrics
+  actionable_steps:
+    - Configure Git provider webhooks and CI/CD API access.
+    - Pull incident management data for failure tracking.
+  dependencies: [157, 158]
+  acceptance_criteria:
+    - Data required for DORA and SPACE metrics is collected automatically.
+  priority: 2
+  status: pending
+  epic: Observability
+
+- id: 167
+  task_id: P2-T2
+  title: Instrument Unified Metrics Catalog
+  description: Instrument the full set of SLIs from the Unified AI-SWA Metrics Catalog.
+  area: metrics
+  actionable_steps:
+    - Add instrumentation hooks for all defined SLIs.
+    - Verify metrics appear in Prometheus.
+  dependencies: [166]
+  acceptance_criteria:
+    - Each SLI in the catalog has a corresponding metric in Prometheus.
+  priority: 2
+  status: pending
+  epic: Observability
+
+- id: 168
+  task_id: P2-T3
+  title: Define Initial SLOs
+  description: Collaborate with teams to establish service level objectives.
+  area: metrics
+  actionable_steps:
+    - Hold workshops with engineering leads.
+    - Document agreed SLOs for each service.
+  dependencies: [167]
+  acceptance_criteria:
+    - SLOs are documented and approved by stakeholders.
+  priority: 2
+  status: pending
+  epic: Observability
+
+- id: 169
+  task_id: P2-T4
+  title: Build DORA and SPACE Dashboards
+  description: Create Grafana dashboards visualizing DORA and SPACE metrics.
+  area: observability
+  actionable_steps:
+    - Use the dashboards-as-code workflow to define panels.
+    - Include visualizations for all key metrics.
+  dependencies: [166, 160, 161]
+  acceptance_criteria:
+    - Grafana dashboards display DORA and SPACE metrics side by side.
+  priority: 2
+  status: pending
+  epic: Observability
+
+- id: 170
+  task_id: P2-T5
+  title: Collect Developer Perceptual Data
+  description: Launch surveys to measure developer satisfaction and burnout.
+  area: metrics
+  actionable_steps:
+    - Deploy quarterly anonymous surveys.
+    - Aggregate results into Prometheus gauges.
+  dependencies: [166]
+  acceptance_criteria:
+    - Survey results are stored and visualized in Grafana.
+  priority: 3
+  status: pending
+  epic: Observability
+
+- id: 171
+  task_id: P3-T1
+  title: Analyze Telemetry Volume
+  description: Measure production telemetry volume and collector performance.
+  area: observability
+  actionable_steps:
+    - Gather baseline metrics on collector throughput.
+    - Identify optimization opportunities.
+  dependencies: [157, 158]
+  acceptance_criteria:
+    - Report documenting telemetry load and proposed optimizations.
+  priority: 3
+  status: pending
+  epic: Observability
+
+- id: 172
+  task_id: P3-T3
+  title: Tune Collector Resources
+  description: Adjust CPU and memory limits for OpenTelemetry Collectors based on production load.
+  area: observability
+  actionable_steps:
+    - Benchmark collector performance under load.
+    - Update deployment manifests with optimized limits.
+  dependencies: [171]
+  acceptance_criteria:
+    - Collectors operate within resource budgets without drops.
+  priority: 3
+  status: pending
+  epic: Observability
+
+- id: 173
+  task_id: P3-T4
+  title: Build Custom Collector Images
+  description: Use OpenTelemetry Collector Builder to create lean images.
+  area: observability
+  actionable_steps:
+    - Configure ocb with required components only.
+    - Publish optimized collector images to the registry.
+  dependencies: [171]
+  acceptance_criteria:
+    - Custom images run successfully in staging and production.
+  priority: 3
+  status: pending
+  epic: Observability
+
+- id: 174
+  task_id: P4-T2
+  title: Select Initial Optimization Problem
+  description: Choose the first production service for RL-based optimization.
+  area: reflector
+  actionable_steps:
+    - Review service metrics to identify scaling pain points.
+    - Document the chosen optimization target.
+  dependencies: [163]
+  acceptance_criteria:
+    - Optimization problem statement is approved by engineering leadership.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+
+- id: 175
+  task_id: P4-T4
+  title: Train First RL Agent
+  description: Train the Reflector Core agent using simulation data.
+  area: reflector
+  actionable_steps:
+    - Run imitation learning phase using historical data.
+    - Continue training with PPO until convergence.
+  dependencies: [164, 174]
+  acceptance_criteria:
+    - Training produces a policy that meets defined SLO targets in simulation.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+
+- id: 176
+  task_id: P4-T6
+  title: Enable Automated Actions
+  description: Gradually permit the RL agent to take actions in production.
+  area: reflector
+  actionable_steps:
+    - Implement safeguards and monitoring for automated actions.
+    - Roll out authority incrementally based on shadow mode results.
+  dependencies: [165, 175]
+  acceptance_criteria:
+    - Agent actions can be enabled with human override.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+
+- id: 177
+  task_id: P1T1
+  title: Setup Project Environment and MARL Framework
+  description: Initialize repository and install MARLlib with dependencies.
+  area: reflector
+  actionable_steps:
+    - Configure Python environment and dependency management.
+    - Install and verify MARLlib framework.
+    - Initialize Git repository hooks for CI.
+  dependencies: []
+  acceptance_criteria:
+    - Repository builds with MARLlib installed.
+    - Basic training script runs without error.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 178
+  task_id: P1T2
+  title: Implement CI/CD Simulation Environment
+  description: Create a discrete-event simulation modeling the CI/CD pipeline.
+  area: reflector
+  actionable_steps:
+    - Model commit queue and pipeline stages with resource constraints.
+    - Simulate resource consumption and job durations.
+    - Provide interfaces for the CI/CD agent to interact with the environment.
+  dependencies: [177]
+  acceptance_criteria:
+    - Simulation produces realistic metrics for pipeline execution.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 179
+  task_id: P1T3
+  title: Implement Production Stability Simulation Environment
+  description: Build a simulation representing production service health and incidents.
+  area: reflector
+  actionable_steps:
+    - Model service telemetry such as error rates and latency.
+    - Include infrastructure metrics and incident states.
+    - Support ingestion of real workload patterns.
+  dependencies: [177]
+  acceptance_criteria:
+    - Simulation can reproduce known incident scenarios.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 180
+  task_id: P1T4
+  title: Define and Implement Core Agent Interfaces
+  description: Implement Python classes for CI/CD and Stability agents with defined SAR spaces.
+  area: reflector
+  actionable_steps:
+    - Define state, action, and reward data structures.
+    - Ensure compatibility with MARLlib environment APIs.
+    - Stub agent classes for future training.
+  dependencies: [178, 179]
+  acceptance_criteria:
+    - Agents compile and can step through both simulations.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 181
+  task_id: P2T1
+  title: Implement Recurrent Policy Network Model
+  description: Create a neural network with LSTM layers to handle partial observability.
+  area: reflector
+  actionable_steps:
+    - Design the recurrent architecture for agent policies.
+    - Integrate the model with MARLlib.
+  dependencies: [180]
+  acceptance_criteria:
+    - Model passes unit tests and can process sequence batches.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 182
+  task_id: P2T2
+  title: Configure Recurrent PPO Trainer
+  description: Set up MARLlib training configuration for Recurrent PPO.
+  area: reflector
+  actionable_steps:
+    - Enable trajectory-based sampling.
+    - Register the recurrent model with the trainer.
+  dependencies: [181]
+  acceptance_criteria:
+    - Training loop initializes with recurrent policy.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 183
+  task_id: P2T3
+  title: Train Agents and Baseline
+  description: Train recurrent agents and a non-recurrent baseline in the simulations.
+  area: reflector
+  actionable_steps:
+    - Execute training runs for recurrent agents.
+    - Train a baseline MLP PPO agent for comparison.
+  dependencies: [182]
+  acceptance_criteria:
+    - Training completes and logs rewards for both agent types.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 184
+  task_id: P2T4
+  title: Analyze and Compare Performance
+  description: Evaluate trained agents against the baseline using cumulative reward metrics.
+  area: reflector
+  actionable_steps:
+    - Gather evaluation results from simulation runs.
+    - Produce a summary comparing recurrent and baseline agents.
+  dependencies: [183]
+  acceptance_criteria:
+    - Report shows performance improvement of recurrent agent.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 185
+  task_id: P3T1
+  title: Generate Explanation Dataset
+  description: Collect state-action pairs from a trained agent for explainability.
+  area: reflector
+  actionable_steps:
+    - Run the trained agent to record observations and actions.
+    - Save dataset for proxy model training.
+  dependencies: [183]
+  acceptance_criteria:
+    - Dataset contains sufficient samples for training a proxy model.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 186
+  task_id: P3T2
+  title: Train Decision Tree Proxy Model
+  description: Train a decision tree to mimic the agent's policy.
+  area: reflector
+  actionable_steps:
+    - Split the explanation dataset into train and test sets.
+    - Fit a decision tree classifier with limited depth.
+  dependencies: [185]
+  acceptance_criteria:
+    - Proxy model fits without overfitting and can be exported.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 187
+  task_id: P3T3
+  title: Evaluate Proxy Model Fidelity
+  description: Measure how well the decision tree replicates agent actions.
+  area: reflector
+  actionable_steps:
+    - Compute accuracy of proxy predictions on held-out data.
+    - Assess stability of explanations across similar states.
+  dependencies: [186]
+  acceptance_criteria:
+    - Fidelity metrics meet defined thresholds.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 188
+  task_id: P3T4
+  title: Visualize and Document Explanations
+  description: Create visualizations of the decision tree and document findings.
+  area: reflector
+  actionable_steps:
+    - Generate diagrams of the pruned decision tree.
+    - Document explanation examples in project reports.
+  dependencies: [187]
+  acceptance_criteria:
+    - Visualizations are stored in docs and referenced in README.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 189
+  task_id: P4T1
+  title: Implement Inter-Agent Coordination
+  description: Add hybrid reward sharing and centralized critic for agent cooperation.
+  area: reflector
+  actionable_steps:
+    - Define shared global reward function.
+    - Configure centralized critic in MARLlib.
+  dependencies: [184]
+  acceptance_criteria:
+    - Agents share rewards and training completes without instability.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 190
+  task_id: P4T2
+  title: Define and Implement Developer Flow Agent
+  description: Build an agent focused on optimizing DORA metrics.
+  area: reflector
+  actionable_steps:
+    - Implement state, action, and reward definitions for the agent.
+    - Integrate the agent into the simulation environment.
+  dependencies: [189]
+  acceptance_criteria:
+    - Developer Flow agent can participate in multi-agent training.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 191
+  task_id: P4T3
+  title: Run Integrated Multi-Agent Training
+  description: Train all agents together using CTDE and hybrid rewards.
+  area: reflector
+  actionable_steps:
+    - Launch multi-agent training sessions in combined simulations.
+    - Monitor global and local reward metrics.
+  dependencies: [190]
+  acceptance_criteria:
+    - Integrated agents converge on stable policies.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 192
+  task_id: P4T4
+  title: Evaluate System-Level KPIs
+  description: Assess the integrated system against business and operational goals.
+  area: reflector
+  actionable_steps:
+    - Measure overall cost, stability, and velocity metrics.
+    - Document trade-offs achieved by the multi-agent system.
+  dependencies: [191]
+  acceptance_criteria:
+    - Evaluation report demonstrates improvements over baseline.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 193
+  task_id: P5T1
+  title: Document Code and Architecture
+  description: Write comprehensive documentation for simulations and agents.
+  area: docs
+  actionable_steps:
+    - Document environment setup, training configuration, and interfaces.
+    - Ensure architecture diagrams are up to date.
+  dependencies: [192]
+  acceptance_criteria:
+    - Documentation covers all modules and is linked from README.
+  priority: 2
+  status: pending
+  epic: Reflector Core
+- id: 194
+  task_id: P5T2
+  title: Prepare Final Project Report
+  description: Summarize project methodology, results, and future work.
+  area: docs
+  actionable_steps:
+    - Compile performance evaluations and explanation visuals.
+    - Outline recommendations for further research.
+  dependencies: [193]
+  acceptance_criteria:
+    - Final report is published in the docs directory.
+  priority: 2
+  status: pending
+  epic: Reflector Core


### PR DESCRIPTION
## Summary
- extend project plan with tasks for multi-agent Reflector Core development

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686c41b25ff4832a820be1116897f717