### PR TITLE
Lock deps & doc test issues

### DIFF
--- a/docs/ci/running_bandit.md
+++ b/docs/ci/running_bandit.md
@@ -2,9 +2,9 @@
 
 The CI workflow uses [Bandit](https://bandit.readthedocs.io) to scan the source code for security issues. To reproduce the scan locally:
 
-1. Install the dependencies:
+1. Install the dependencies from the lock file:
    ```bash
-   pip install -r requirements.txt
+   pip install -r requirements.lock
    ```
 2. Run Bandit from the project root:
    ```bash

--- a/docs/reviews/ci_flaky_tests.md
+++ b/docs/reviews/ci_flaky_tests.md
@@ -1,0 +1,9 @@
+# CI Test Review
+
+A local run of the test suite exposed failures related to missing test dependencies:
+
+```
+E   RuntimeError: The starlette.testclient module requires the httpx package to be installed.
+```
+
+The `tests/test_broker_api.py` import `fastapi.testclient` which depends on `httpx`. This package is not listed in `requirements.txt`, causing the suite to fail. Adding `httpx` to the development dependencies or vendor tests can resolve this issue.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 PyYAML==6.0.2
 pytest==8.4.1
 jsonschema==4.24.0
-radon==5.1.0
-wily==1.25.0
-pylint==3.3.7
-bandit==1.7.8
+radon==5.1.0  # code complexity metrics
+wily==1.25.0  # git-based code analytics
+pylint==3.3.7  # static code analysis
+bandit==1.7.8  # security scanning
 fastapi==0.116.0
 uvicorn==0.35.0
 requests==2.32.4
-opentelemetry-sdk==1.34.1
-opentelemetry-exporter-prometheus==0.55b1
-opentelemetry-instrumentation-fastapi==0.55b1
-grafanalib==0.7.1
-grpcio==1.73.1
-grpcio-tools==1.73.1
+opentelemetry-sdk==1.34.1  # telemetry core
+opentelemetry-exporter-prometheus==0.55b1  # prometheus exporter
+opentelemetry-instrumentation-fastapi==0.55b1  # auto-instrument FastAPI
+grafanalib==0.7.1  # grafana dashboards as code
+grpcio==1.73.1  # gRPC runtime
+grpcio-tools==1.73.1  # gRPC code generation


### PR DESCRIPTION
## Summary
- annotate uncommon packages in `requirements.txt`
- regenerate `requirements.lock`
- update documentation to install Bandit from the lock file
- record failing CI test run details

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: httpx missing)*

------
https://chatgpt.com/codex/tasks/task_e_686dd34dbf94832ab0e0037d52dc3cc8