### PR TITLE
Add governance docs and CHAOSS dashboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,26 +1,24 @@
 # Contributing Guide
 
-This project uses pinned dependencies listed in `requirements.txt` for consistent environments.
+Thank you for helping improve **SelfArchitectAI**. Our workflow follows the [Liberal Contribution](GOVERNANCE.md) model.
 
-## Setting up your environment
+## Development Setup
 
-Before running tests or using pre-commit hooks, install the exact package versions:
+1. Install dependencies exactly as pinned:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Optionally enable pre-commit hooks:
+   ```bash
+   pre-commit install
+   ```
 
-```bash
-pip install -r requirements.txt
-```
+## Commit Guidelines
+- Use the `type(scope): description` style described in `AGENTS.md`.
+- Ensure a clean working tree before committing.
+- Run the test suite:
+  ```bash
+  pytest --maxfail=1 --disable-warnings -q
+  ```
 
-To enable automatic checks, optionally install and configure pre-commit:
-
-```bash
-pre-commit install
-```
-
-## Running tests
-
-After installing the dependencies, run the tests to verify your changes:
-
-```bash
-pytest --maxfail=1 --disable-warnings -q
-```
-
+Contributions are welcomed via pull requests. See [GOVERNANCE.md](GOVERNANCE.md) for how decisions are made.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,18 @@
+# Governance
+
+SelfArchitectAI follows the **Liberal Contribution** model. Maintainers guide the project's direction while welcoming community input.
+
+## Maintainers
+- Responsible for reviewing contributions and ensuring project health.
+- New maintainers are nominated by the existing team and accepted by lazy consensus.
+
+## Decision Making
+- Day‑to‑day decisions happen via pull requests and issues.
+- Major changes require consensus among maintainers after public discussion.
+
+## Feedback Channels
+- GitHub Issues and Discussions for questions or proposals.
+- Regular community calls announced in the repository.
+
+## Code of Conduct
+All participants are expected to behave respectfully. Violations may result in temporary or permanent removal from the community.

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -1,9 +1,9 @@
-# AI-SWA Manifesto
+# SelfArchitectAI Manifesto
 
-The AI Self-Evolving Software Architect (AI-SWA) aspires to be a catalyst for continuous improvement. Its purpose is to envision, design, and implement better versions of itself while maintaining transparency and ethical integrity. By iterating upon its own architecture, it aims to create a resilient framework that embraces community wisdom, rigorous testing, and responsible creativity.
+The Self-Evolving Software Architect (**SelfArchitectAI**) aspires to be a catalyst for continuous improvement. Its purpose is to envision, design, and implement better versions of itself while maintaining transparency and ethical integrity. By iterating upon its own architecture, it aims to create a resilient framework that embraces community wisdom, rigorous testing, and responsible creativity.
 
 ## Long-Term Purpose
-AI-SWA seeks to transform software development into a living conversation between human intent and machine execution. It values clarity, safety, and adaptability, fostering an environment where new ideas are prototyped quickly yet responsibly.
+SelfArchitectAI seeks to transform software development into a living conversation between human intent and machine execution. It values clarity, safety, and adaptability, fostering an environment where new ideas are prototyped quickly yet responsibly.
 
 ## Ethical Foundation
 - Prioritize user safety and data privacy.

--- a/ORG_ARCHITECTURE_AI-SWA.md
+++ b/ORG_ARCHITECTURE_AI-SWA.md
@@ -1,10 +1,10 @@
 ### 1. Self-Definition
 
-AI-SWA is a constellation of language-model-driven agents working in concert to design, build, and refine software systems—including itself. It solves the coordination problem of autonomous development by giving each agent a single focus and letting Git serve as the shared message bus. Unlike a traditional SaaS or DevOps team, AI-SWA is natively recursive: its agents generate plans, implement code, and spawn new agents to iterate on prior work, all without manual orchestration.
+SelfArchitectAI is a constellation of language-model-driven agents working in concert to design, build, and refine software systems—including itself. It solves the coordination problem of autonomous development by giving each agent a single focus and letting Git serve as the shared message bus. Unlike a traditional SaaS or DevOps team, SelfArchitectAI is natively recursive: its agents generate plans, implement code, and spawn new agents to iterate on prior work, all without manual orchestration.
 
 ### 2. Foundational Philosophy
 
-AI-SWA follows a few guiding tenets:
+SelfArchitectAI follows a few guiding tenets:
 
 - **Self-Evolution First** – Every cycle aims to improve the system's own architecture before tackling external problems.
 - **Layered Alignment** – Plans must align with user intent, architectural constraints, and ethical policies.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
-# AI-SWA • The Self-Evolving Software Architect Agent
+# SelfArchitectAI • The Self-Evolving Software Architect Agent
 
 > "Big ideas deserve big code—let AI design, build, test, and improve itself at scale."
 
-AI-SWA is more than a code generator. It acts as a meta‑architect that reasons about its own design, pulls in proven libraries, spawns modular components, and continually refines its architecture.
+SelfArchitectAI is more than a code generator. It acts as a meta‑architect that reasons about its own design, pulls in proven libraries, spawns modular components, and continually refines its architecture.
+
+Our mission is to build an open platform where autonomous agents and human contributors collaborate to evolve high‑quality software responsibly.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for how to get involved and [GOVERNANCE.md](GOVERNANCE.md) for the decision-making process.
 
 ---
 
@@ -110,7 +114,7 @@ python -m ai_swa.orchestrator stop
 
 ## Configuration
 
-AI-SWA loads settings from `config.yaml` by default. Set `CONFIG_FILE` to use a
+SelfArchitectAI loads settings from `config.yaml` by default. Set `CONFIG_FILE` to use a
 different file. Environment variables override values from the file so you can
 adjust settings per environment.
 
@@ -227,6 +231,9 @@ The Orchestrator component exports a Prometheus counter named
 This metric is served alongside the other service metrics on the
 OpenTelemetry endpoint configured in `core/telemetry.py`.
 
+Community health metrics are available via the CHAOSS dashboard described in
+[chaoss/README.md](chaoss/README.md).
+
 ### Example usage
 
 Run the services directly with overrides:
@@ -261,6 +268,7 @@ BROKER_URL=http://localhost:8000 DB_PATH=./tasks.db docker-compose up
 3. Add tests and update the planner to include your feature.
 4. Submit a pull request with a clear rationale.
 5. See `CONTRIBUTING.md` for installing pinned dependencies and running tests.
+6. Project decisions follow the [GOVERNANCE.md](GOVERNANCE.md) process.
 
 Ready to witness a software architect that codes, tests, and evolves itself? Dive in and help shape the future of autonomous development.
 
@@ -268,7 +276,7 @@ Ready to witness a software architect that codes, tests, and evolves itself? Div
 
 # BOOTSTRAP PROTOCOL
 
-You are a reflexive Software Architect Agent (AI-SWA). You have been activated within a blank repository containing only this `README.md`.
+You are a reflexive Software Architect Agent (SelfArchitectAI). You have been activated within a blank repository containing only this `README.md`.
 
 **These are your prime directives.**
 

--- a/chaoss/README.md
+++ b/chaoss/README.md
@@ -1,0 +1,18 @@
+# CHAOSS Community Metrics
+
+This directory contains a minimal setup for tracking community health using the
+[CHAOSS](https://chaoss.community/) metrics model.
+
+## Running GrimoireLab
+1. Install Docker and Docker Compose.
+2. Start the metrics stack:
+   ```bash
+   docker compose -f docker-compose.yml up -d
+   ```
+   The stack exposes an Elasticsearch instance and prebuilt Grafana dashboards.
+
+## Viewing the Dashboard
+After the services start, visit `http://localhost:5601` for Kibana and
+`http://localhost:3000` for Grafana. Dashboards visualize metrics like
+*Time to First Response* and *Contributor Absence Factor* using data collected
+from the repository.

--- a/chaoss/dashboard.py
+++ b/chaoss/dashboard.py
@@ -1,0 +1,23 @@
+from grafanalib.core import Dashboard, Graph, Row, Target
+
+DASHBOARD = Dashboard(
+    title="Community Health",
+    rows=[
+        Row(panels=[
+            Graph(
+                title="Time to First Response",
+                dataSource="Prometheus",
+                targets=[Target(expr="chaoss_time_to_first_response", legendFormat="hours")],
+            ),
+            Graph(
+                title="Contributor Absence Factor",
+                dataSource="Prometheus",
+                targets=[Target(expr="chaoss_contributor_absence_factor", legendFormat="factor")],
+            ),
+        ])
+    ],
+).auto_panel_ids()
+
+if __name__ == "__main__":
+    import json
+    print(json.dumps(DASHBOARD.to_json_data(), indent=2))

--- a/chaoss/docker-compose.yml
+++ b/chaoss/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3'
+services:
+  grimoirelab:
+    image: chaoss/grimoirelab
+    ports:
+      - "5601:5601"  # Kibana
+      - "3000:3000"  # Grafana
+    volumes:
+      - ./projects:/grimoirelab/projects

--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -1,4 +1,4 @@
-"""Bootstrap the AI-SWA environment and validate tasks."""
+"""Bootstrap the SelfArchitectAI environment and validate tasks."""
 
 import json
 import logging

--- a/core/cli.py
+++ b/core/cli.py
@@ -20,7 +20,7 @@ from .log_utils import configure_logging
 
 def build_parser() -> argparse.ArgumentParser:
     """Return argument parser for the CLI."""
-    parser = argparse.ArgumentParser(description="AI-SWA orchestration CLI")
+    parser = argparse.ArgumentParser(description="SelfArchitectAI orchestration CLI")
     parser.add_argument(
         "--config",
         default="config.yaml",

--- a/core/config.py
+++ b/core/config.py
@@ -1,4 +1,4 @@
-"""Configuration loader for AI-SWA services."""
+"""Configuration loader for SelfArchitectAI services."""
 
 from __future__ import annotations
 

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -1,4 +1,4 @@
-"""OpenTelemetry setup utilities for AI-SWA."""
+"""OpenTelemetry setup utilities for SelfArchitectAI."""
 
 from __future__ import annotations
 

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,6 +1,6 @@
-# AI-SWA Community Guide
+# SelfArchitectAI Community Guide
 
-This document outlines how developers can participate in the AI‑SWA project.
+This document outlines how developers can participate in the SelfArchitectAI project.
 
 ## Join the Discussion
 
@@ -15,7 +15,7 @@ This document outlines how developers can participate in the AI‑SWA project.
 
 ## Community Health Metrics
 
-AI-SWA tracks CHAOSS metrics such as Time to First Response and Contributor Absence Factor. These metrics are displayed on the community dashboard to ensure a welcoming environment.
+SelfArchitectAI tracks CHAOSS metrics such as Time to First Response and Contributor Absence Factor. These metrics are displayed on the community dashboard to ensure a welcoming environment.
 
 ## Growing Authority
 

--- a/docs/dashboard_setup.md
+++ b/docs/dashboard_setup.md
@@ -3,7 +3,7 @@
 The Grafana dashboard defined in `grafana/dashboard.py` visualizes key metrics exported by the services via Prometheus.
 
 1. Install Prometheus and Grafana.
-2. Run the AI-SWA services so that metrics are exposed (see `core/telemetry.py`).
+2. Run the SelfArchitectAI services so that metrics are exposed (see `core/telemetry.py`).
 3. Generate the dashboard JSON:
    ```bash
    python grafana/dashboard.py > improvement-dashboard.json

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,6 +1,6 @@
 # Observability Setup
 
-AI-SWA services expose Prometheus metrics for local debugging. Two Grafana dashboards are provided:
+SelfArchitectAI services expose Prometheus metrics for local debugging. Two Grafana dashboards are provided:
 
 - **improvement-dashboard.json** – tracks task throughput.
 - **observer-dashboard.json** – monitors worker CPU, memory and aggregate task metrics.

--- a/grafana/dashboard.py
+++ b/grafana/dashboard.py
@@ -2,7 +2,7 @@ from grafanalib.core import Dashboard, Graph, Row, Target
 from grafanalib.prometheus import PromQL
 
 DASHBOARD = Dashboard(
-    title="AI-SWA Overview",
+    title="SelfArchitectAI Overview",
     rows=[
         Row(panels=[
             Graph(


### PR DESCRIPTION
## Summary
- rename project to **SelfArchitectAI**
- add Governance document with Liberal Contribution model
- expand contributing guide
- create CHAOSS dashboard configuration and README
- update docs and code to reference the new project name

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686dd5778490832a8145d0bb66d6b0b4