### PR TITLE
feat(observability): deploy OPG stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,16 +212,16 @@ Set `SNYK_TOKEN`, `COSIGN_KEY`, and `COSIGN_PASSWORD` secrets to enable these st
 All services expose Prometheus-compatible metrics. The Node I/O service uses
 `prom-client` to call `collectDefaultMetrics()` and serves them at `/metrics`
 (default port `9100`). The broker and worker export metrics on ports `9000` and
-`9001` respectively. Configure Prometheus to scrape these endpoints:
+`9001` respectively. In the default Docker Compose deployment an OpenTelemetry
+Collector receives OTLP data from each service and exposes it via a secured
+Prometheus endpoint. Configure Prometheus to scrape the collector:
 
 ```yaml
 scrape_configs:
   - job_name: ai_swa
     static_configs:
       - targets:
-          - 'localhost:9000'
-          - 'localhost:9001'
-          - 'localhost:9100'
+          - 'localhost:8889'
 ```
 
 Use the appropriate hostnames if running under Docker Compose or Kubernetes.

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -3,15 +3,18 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Tuple
 
 try:
     from opentelemetry import metrics, trace
     from opentelemetry.metrics import set_meter_provider, get_meter_provider
     from opentelemetry.sdk.metrics import MeterProvider
+    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
     from opentelemetry.exporter.prometheus import PrometheusMetricReader, start_http_server
+    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
     from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
     from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogExporter
@@ -19,17 +22,42 @@ except Exception:  # pragma: no cover - optional dependency
     metrics = trace = None
 
 
-def setup_telemetry(service_name: str = "ai_swa", metrics_port: int = 8000) -> Tuple[object, object]:
-    """Configure OpenTelemetry providers and start the Prometheus metrics server."""
+def setup_telemetry(
+    service_name: str = "ai_swa",
+    metrics_port: int = 8000,
+    otlp_endpoint: str | None = None,
+    otlp_cert_path: str | None = None,
+) -> Tuple[object, object]:
+    """Configure OpenTelemetry providers and start the Prometheus metrics server.
+
+    If ``otlp_endpoint`` is provided (or ``OTEL_EXPORTER_OTLP_ENDPOINT`` is set in
+    the environment), metrics are also exported via OTLP to that endpoint. When a
+    certificate path is supplied, it is used to secure the connection.
+    """
 
     if metrics is None:
         raise ImportError("opentelemetry is required for telemetry")
 
     resource = Resource.create({"service.name": service_name})
 
-    # Metrics provider with Prometheus exporter
-    reader = PrometheusMetricReader()
-    meter_provider = MeterProvider(metric_readers=[reader], resource=resource)
+    metric_readers = []
+
+    # Export metrics via OTLP if configured
+    otlp_endpoint = otlp_endpoint or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    otlp_cert_path = otlp_cert_path or os.getenv("OTEL_EXPORTER_OTLP_CERTIFICATE")
+    if otlp_endpoint:
+        exporter = OTLPMetricExporter(
+            endpoint=otlp_endpoint,
+            insecure=not bool(otlp_cert_path),
+            certificate_file=otlp_cert_path,
+        )
+        metric_readers.append(PeriodicExportingMetricReader(exporter))
+
+    # Metrics provider with Prometheus exporter for scraping
+    prom_reader = PrometheusMetricReader()
+    metric_readers.append(prom_reader)
+
+    meter_provider = MeterProvider(metric_readers=metric_readers, resource=resource)
     set_meter_provider(meter_provider)
     server, thread = start_http_server(port=metrics_port)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,10 +12,14 @@ services:
       BROKER_URL: http://broker:8000
       WORKER_METRICS_PORT: "9001"
       BROKER_METRICS_PORT: "9000"
+      OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
+      OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
     depends_on:
       - broker
       - worker
       - io-service
+    volumes:
+      - ./observability/certs:/certs:ro
   broker:
     build:
       context: .
@@ -23,8 +27,11 @@ services:
     environment:
       DB_PATH: /data/tasks.db
       BROKER_METRICS_PORT: "9000"
+      OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
+      OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
     volumes:
       - broker-data:/data
+      - ./observability/certs:/certs:ro
     ports:
       - "8000:8000"
       - "9000:9000"
@@ -35,16 +42,25 @@ services:
     environment:
       BROKER_URL: http://broker:8000
       WORKER_METRICS_PORT: "9001"
+      OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
+      OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
     depends_on:
       - broker
+    volumes:
+      - ./observability/certs:/certs:ro
     ports:
       - "9001:9001"
   orchestrator-api:
     build:
       context: .
       dockerfile: orchestrator_api/Dockerfile
+    environment:
+      OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
+      OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
     depends_on:
       - orchestrator
+    volumes:
+      - ./observability/certs:/certs:ro
     ports:
       - "8002:8002"
   api-gateway:
@@ -54,9 +70,13 @@ services:
     environment:
       BROKER_URL: http://broker:8000
       ORCH_URL: http://orchestrator-api:8002
+      OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
+      OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
     depends_on:
       - broker
       - orchestrator-api
+    volumes:
+      - ./observability/certs:/certs:ro
     ports:
       - "8080:8080"
   io-service:
@@ -64,6 +84,8 @@ services:
     environment:
       PORT: "50051"
       METRICS_PORT: "9100"
+      OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
+      OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9100/health"]
       interval: 5s
@@ -74,6 +96,44 @@ services:
       - "9100:9100"
     volumes:
       - node-data:/data
+      - ./observability/certs:/certs:ro
+
+  otel-collector:
+    image: otel/opentelemetry-collector:0.93.0
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ./observability/otel-collector.yaml:/etc/otelcol/config.yaml:ro
+      - ./observability/certs:/certs:ro
+    ports:
+      - "4317:4317"
+      - "8889:8889"
+    healthcheck:
+      test: ["CMD", "otelcol", "--version"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./observability/certs:/certs:ro
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    volumes:
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./observability/certs:/certs:ro
+    environment:
+      GF_SERVER_PROTOCOL: https
+      GF_SERVER_CERT_FILE: /certs/collector.crt
+      GF_SERVER_CERT_KEY: /certs/collector.key
+    depends_on:
+      - prometheus
+    ports:
+      - "3000:3000"
 
 volumes:
   broker-data:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,15 +1,16 @@
 # Observability Setup
 
-SelfArchitectAI services expose Prometheus metrics for local debugging. Two Grafana dashboards are provided:
+SelfArchitectAI services expose Prometheus metrics for local debugging. Two Grafana dashboards are provided and the stack now includes an OpenTelemetry Collector that receives OTLP data from each service and exports it for Prometheus scraping over TLS.
 
 - **improvement-dashboard.json** – tracks task throughput.
 - **observer-dashboard.json** – monitors worker CPU, memory and aggregate task metrics.
 
 ## Usage
 
-1. Run the stack with `docker-compose up` or start the services manually.
-2. Execute `python scripts/update_dashboards.py` to regenerate the dashboard JSON files.
-3. Import the JSON files into Grafana and set Prometheus as the data source.
+1. Run `observability/generate_certs.sh` once to create self‑signed certificates used by Prometheus, Grafana and the collector.
+2. Start the stack with `docker-compose up`.
+3. Execute `python scripts/update_dashboards.py` to regenerate the dashboard JSON files.
+4. The dashboards are automatically loaded and Prometheus is pre-configured as a data source.
 
 Running the update script ensures the dashboards stay current during local runs.
 

--- a/observability/generate_certs.sh
+++ b/observability/generate_certs.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+DIR="$(dirname "$0")/certs"
+mkdir -p "$DIR"
+openssl req -x509 -nodes -newkey rsa:2048 -days 365 \
+  -subj "/CN=localhost" \
+  -keyout "$DIR/collector.key" -out "$DIR/collector.crt"
+cp "$DIR/collector.crt" "$DIR/ca.crt"
+cp "$DIR/collector.key" "$DIR/ca.key"

--- a/observability/grafana/provisioning/datasources/datasource.yml
+++ b/observability/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: https://prometheus:9090
+    basicAuth: false
+    isDefault: true
+    jsonData:
+      tlsSkipVerify: true

--- a/observability/otel-collector.yaml
+++ b/observability/otel-collector.yaml
@@ -1,0 +1,22 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+        tls:
+          cert_file: /certs/collector.crt
+          key_file: /certs/collector.key
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    tls:
+      cert_file: /certs/collector.crt
+      key_file: /certs/collector.key
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [prometheus]
+  telemetry:
+    metrics:
+      address: 0.0.0.0:8888

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: 'otel-collector'
+    scheme: https
+    tls_config:
+      ca_file: /certs/ca.crt
+      insecure_skip_verify: true
+    static_configs:
+      - targets: ['otel-collector:8889']

--- a/requirements.lock
+++ b/requirements.lock
@@ -91,6 +91,8 @@ opentelemetry-api==1.34.1
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-prometheus==0.55b1
     # via -r requirements.txt
+opentelemetry-exporter-otlp-proto-grpc==1.34.1
+    # via -r requirements.txt
 opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-asgi

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ opentelemetry-instrumentation-fastapi==0.55b1  # auto-instrument FastAPI
 grafanalib==0.7.1  # grafana dashboards as code
 grpcio==1.73.1  # gRPC runtime
 grpcio-tools==1.73.1  # gRPC code generation
+opentelemetry-exporter-otlp-proto-grpc==1.34.1  # OTLP exporter
+protobuf==6.31.1

--- a/tasks.yml
+++ b/tasks.yml
@@ -1255,7 +1255,7 @@
     - Grafana is configured with Prometheus as a data source.
     - All observability components expose their own health metrics.
   priority: 1
-  status: pending
+  status: done
   epic: Observability
 
 - id: 158


### PR DESCRIPTION
## Summary
- provision Prometheus, Grafana and an OTLP collector via docker-compose
- add TLS certificate generation script
- export OTLP metrics from services
- document new observability flow
- mark observability task OBS-01 as done

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686dd79f5878832a8ef0d16d539a685d