### PR TITLE
Add Jaeger OAL integration outline

### DIFF
--- a/docs/integrations/jaeger_oal_integration.md
+++ b/docs/integrations/jaeger_oal_integration.md
@@ -1,0 +1,40 @@
+# Jaeger Language Processor with SkyWalking OAL
+
+This guide outlines a high-level approach for combining the Open Source engine in this repository with the Apache SkyWalking OAL (Observability Analysis Language) engine. The goal is to translate Jaeger tracing data using OAL rules so it can be processed standalone, outside of a full SkyWalking deployment.
+
+## Prerequisites
+
+- **Apache SkyWalking OAL engine** – build the `oal-rt` module from the [SkyWalking](https://github.com/apache/skywalking) project.
+- **AI-SWA engine** – core modules from this repo providing task orchestration and plugin loading.
+- **Jaeger trace storage** – access to a Jaeger backend or exported `.json` trace files.
+
+## Integration Steps
+
+1. **Expose the OAL Engine**
+   - Build the SkyWalking `oal-rt` artifact and package its classes into a Python-accessible JAR using `jep` or `py4j`.
+   - Define a thin Python wrapper that forwards Jaeger spans to the OAL runtime and collects emitted metrics.
+
+2. **Create a Processing Plugin**
+   - Implement a plugin under `plugins/` that uses the wrapper to load OAL scripts and execute them on batches of Jaeger spans.
+   - The plugin should expose actions such as `load_oal(file_path)` and `process_traces(span_list)`.
+
+3. **Standalone CLI Driver**
+   - Add a command under `core/cli.py` (e.g., `process-jaeger`) which invokes the plugin directly.
+   - This command reads Jaeger spans from a file or API, runs the OAL engine, and outputs derived metrics.
+
+4. **Task Orchestration**
+   - Register the new plugin in `config.yaml` so the AI-SWA Planner can schedule OAL processing tasks.
+   - Example task:
+     ```yaml
+     - id: 200
+       description: Run OAL rules on Jaeger traces
+       component: observability
+       dependencies: []
+       priority: 3
+       status: pending
+     ```
+
+## Expected Outcome
+
+The resulting processor allows analysts to run OAL scripts against Jaeger traces without deploying the full SkyWalking stack. Metrics produced by the OAL engine can then be forwarded to Prometheus or another backend for visualization.
+


### PR DESCRIPTION
## Summary
- document how to integrate the repo's engine with Apache SkyWalking's OAL engine

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionRefusedError on localhost)*

------
https://chatgpt.com/codex/tasks/task_e_686dddf20b6c832a9d2b6585878fad18