### PR TITLE
feat: gitops workflow for grafana dashboards

### DIFF
--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -1,0 +1,25 @@
+name: Grafana Deploy
+
+on:
+  push:
+    paths:
+      - 'grafana/dashboards/**'
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install requests grafanalib==0.7.1
+      - name: Apply dashboards
+        env:
+          GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
+          GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
+        run: python scripts/apply_dashboards.py

--- a/docs/grafana_gitops.md
+++ b/docs/grafana_gitops.md
@@ -1,0 +1,13 @@
+# Grafana GitOps Workflow
+
+Dashboards for AI-SWA are managed as code and deployed automatically.
+
+1. Run `python scripts/update_dashboards.py` to generate JSON files under
+   `grafana/dashboards/`.
+2. Commit the JSON files to version control. Any change to this directory triggers
+   the `Grafana Deploy` workflow which applies the dashboards to the configured
+   Grafana instance via its HTTP API.
+3. Provide `GRAFANA_URL` and `GRAFANA_API_KEY` as repository secrets so the
+   workflow can authenticate.
+
+This approach keeps Grafana configuration fully declarative and reproducible.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -9,8 +9,10 @@ SelfArchitectAI services expose Prometheus metrics for local debugging. Two Graf
 
 1. Run `observability/generate_certs.sh` once to create self‑signed certificates used by Prometheus, Grafana and the collector.
 2. Start the stack with `docker-compose up`.
-3. Execute `python scripts/update_dashboards.py` to regenerate the dashboard JSON files.
-4. The dashboards are automatically loaded and Prometheus is pre-configured as a data source.
+3. Execute `python scripts/update_dashboards.py` to regenerate the dashboard JSON files in `grafana/dashboards/`.
+4. Commit the JSON files to trigger the `Grafana Deploy` workflow which applies them to Grafana.
 
 Running the update script ensures the dashboards stay current during local runs.
+
+See [Grafana GitOps Workflow](grafana_gitops.md) for details on automated deployment.
 

--- a/grafana/dashboard.py
+++ b/grafana/dashboard.py
@@ -1,5 +1,4 @@
 from grafanalib.core import Dashboard, Graph, Row, Target
-from grafanalib.prometheus import PromQL
 
 DASHBOARD = Dashboard(
     title="SelfArchitectAI Overview",

--- a/grafana/dashboards/improvement-dashboard.json
+++ b/grafana/dashboards/improvement-dashboard.json
@@ -1,0 +1,453 @@
+{
+  "__inputs": [],
+  "annotations": {
+    "list": []
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "panels": [],
+  "refresh": "10s",
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 1,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 4,
+          "targets": [
+            {
+              "expr": "tasks_executed_total",
+              "query": "tasks_executed_total",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "executed",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Tasks Executed",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 2,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 4,
+          "targets": [
+            {
+              "expr": "orchestrator_runs_total",
+              "query": "orchestrator_runs_total",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "runs",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Orchestrator Runs",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 3,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 4,
+          "targets": [
+            {
+              "expr": "rate(task_duration_seconds_sum[1m]) / rate(task_duration_seconds_count[1m])",
+              "query": "rate(task_duration_seconds_sum[1m]) / rate(task_duration_seconds_count[1m])",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "seconds",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Average Task Duration",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        }
+      ],
+      "showTitle": false,
+      "title": "New row",
+      "repeat": null
+    }
+  ],
+  "schemaVersion": 12,
+  "sharedCrosshair": false,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "title": "SelfArchitectAI Overview",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "nowDelay": null,
+    "hidden": false
+  },
+  "timezone": "utc",
+  "version": 0,
+  "uid": null
+}

--- a/grafana/dashboards/observer-dashboard.json
+++ b/grafana/dashboards/observer-dashboard.json
@@ -1,0 +1,591 @@
+{
+  "__inputs": [],
+  "annotations": {
+    "list": []
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "panels": [],
+  "refresh": "10s",
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 1,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "process_cpu_seconds_total",
+              "query": "process_cpu_seconds_total",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "cpu",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Worker CPU Usage",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 2,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "process_resident_memory_bytes",
+              "query": "process_resident_memory_bytes",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "mem",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Worker Memory",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        }
+      ],
+      "showTitle": false,
+      "title": "New row",
+      "repeat": null
+    },
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 3,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "tasks_executed_total",
+              "query": "tasks_executed_total",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "executed",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Tasks Executed",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 4,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "orchestrator_runs_total",
+              "query": "orchestrator_runs_total",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "runs",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Orchestrator Runs",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        }
+      ],
+      "showTitle": false,
+      "title": "New row",
+      "repeat": null
+    }
+  ],
+  "schemaVersion": 12,
+  "sharedCrosshair": false,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "title": "Observer Metrics",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "nowDelay": null,
+    "hidden": false
+  },
+  "timezone": "utc",
+  "version": 0,
+  "uid": null
+}

--- a/grafana/observer_dashboard.py
+++ b/grafana/observer_dashboard.py
@@ -1,5 +1,4 @@
 from grafanalib.core import Dashboard, Graph, Row, Target
-from grafanalib.prometheus import PromQL
 
 OBSERVER_DASHBOARD = Dashboard(
     title="Observer Metrics",

--- a/scripts/apply_dashboards.py
+++ b/scripts/apply_dashboards.py
@@ -1,0 +1,40 @@
+"""Apply Grafana dashboards from JSON files."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Iterable
+
+import requests
+
+GRAFANA_URL = os.getenv("GRAFANA_URL", "http://localhost:3000")
+GRAFANA_API_KEY = os.getenv("GRAFANA_API_KEY")
+DASHBOARD_DIR = Path(os.getenv("DASHBOARD_DIR", "grafana/dashboards"))
+
+
+def iter_dashboards(directory: Path) -> Iterable[Path]:
+    for path in directory.glob("*.json"):
+        if path.is_file():
+            yield path
+
+
+def apply_dashboard(path: Path) -> None:
+    if not GRAFANA_API_KEY:
+        raise RuntimeError("GRAFANA_API_KEY not set")
+    data = json.loads(path.read_text())
+    payload = {"dashboard": data, "overwrite": True}
+    headers = {"Authorization": f"Bearer {GRAFANA_API_KEY}", "Content-Type": "application/json"}
+    response = requests.post(f"{GRAFANA_URL}/api/dashboards/db", json=payload, headers=headers, timeout=10)
+    response.raise_for_status()
+    print(f"Applied {path.name}")
+
+
+def main() -> None:
+    for path in iter_dashboards(DASHBOARD_DIR):
+        apply_dashboard(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update_dashboards.py
+++ b/scripts/update_dashboards.py
@@ -2,18 +2,23 @@
 
 from pathlib import Path
 import json
+from grafanalib._gen import DashboardEncoder
 
 from grafana.dashboard import DASHBOARD
 from grafana.observer_dashboard import OBSERVER_DASHBOARD
 
 
 def write_dashboard(obj, path: Path) -> None:
-    path.write_text(json.dumps(obj.to_json_data(), indent=2))
+    path.write_text(json.dumps(obj.to_json_data(), indent=2, cls=DashboardEncoder))
+
+
+OUTPUT_DIR = Path("grafana/dashboards")
 
 
 def main() -> None:
-    write_dashboard(DASHBOARD, Path("improvement-dashboard.json"))
-    write_dashboard(OBSERVER_DASHBOARD, Path("observer-dashboard.json"))
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    write_dashboard(DASHBOARD, OUTPUT_DIR / "improvement-dashboard.json")
+    write_dashboard(OBSERVER_DASHBOARD, OUTPUT_DIR / "observer-dashboard.json")
     print("Dashboards updated")
 
 

--- a/tasks.yml
+++ b/tasks.yml
@@ -1291,7 +1291,7 @@
     - Editing a dashboard JSON in Git updates Grafana automatically.
     - Grafana dashboards and data sources are fully declarative.
   priority: 2
-  status: pending
+  status: done
   epic: Observability
 
 - id: 160


### PR DESCRIPTION
## Summary
- add Grafana GitOps workflow via GitHub Actions
- store generated dashboards under `grafana/dashboards`
- script to apply dashboards to Grafana over API
- document new workflow and update observability guide
- mark dashboard GitOps task as done

## Testing
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_686deb249bf8832a9cb14fe65842d79d