### PR TITLE
Central config helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ SelfArchitectAI loads settings from `config.yaml` by default. Set the `CONFIG_FI
 environment variable to specify an alternative location. Environment variables always
 override values from the file so you can adjust settings per environment.
 
+Use `config.load_config()` inside any service to access the merged
+configuration dictionary. The returned object contains sections like
+`broker`, `worker`, `node`, `security`, `sandbox`, `planner`, and `logging`.
+
 ### Required environment variables
 
 - `DB_PATH` – path to the broker SQLite database

--- a/ai_swa/orchestrator.py
+++ b/ai_swa/orchestrator.py
@@ -4,6 +4,9 @@ This module exposes the same CLI as :mod:`core.cli`. Available
 subcommands include ``start``, ``stop``, ``status`` and ``list``.
 """
 from core.cli import build_parser, main as cli_main
+from config import load_config
+
+_cfg = load_config()
 
 __all__ = ["build_parser", "main"]
 

--- a/broker/main.py
+++ b/broker/main.py
@@ -27,7 +27,7 @@ except Exception:  # pragma: no cover - optional dependency
     FastAPIInstrumentor = None
     setup_telemetry = None
 from core.security import verify_api_key, verify_token, require_role, User
-from core.config import load_config
+from config import load_config
 from core.log_utils import configure_logging
 
 config = load_config()

--- a/config.py
+++ b/config.py
@@ -1,0 +1,18 @@
+"""Repository-wide configuration helper."""
+
+from core.config import load_config as _load_config
+
+__all__ = ["load_config"]
+
+
+def load_config(path=None):
+    """Return configuration merged with environment overrides.
+
+    Parameters
+    ----------
+    path : str | Path | None, optional
+        Optional path to a YAML configuration file. When omitted the
+        ``CONFIG_FILE`` environment variable or ``config.yaml`` will be used.
+    """
+    return _load_config(path)
+

--- a/core/telemetry.py
+++ b/core/telemetry.py
@@ -14,7 +14,11 @@ try:
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
     from opentelemetry.exporter.prometheus import PrometheusMetricReader, start_http_server
-    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+    # OTLP exporter is optional and may require extra dependencies
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+    except Exception:  # pragma: no cover - optional dependency
+        OTLPMetricExporter = None
     from opentelemetry.sdk.resources import Resource
     from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
     from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, ConsoleLogExporter
@@ -45,7 +49,7 @@ def setup_telemetry(
     # Export metrics via OTLP if configured
     otlp_endpoint = otlp_endpoint or os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT")
     otlp_cert_path = otlp_cert_path or os.getenv("OTEL_EXPORTER_OTLP_CERTIFICATE")
-    if otlp_endpoint:
+    if otlp_endpoint and OTLPMetricExporter:
         exporter = OTLPMetricExporter(
             endpoint=otlp_endpoint,
             insecure=not bool(otlp_cert_path),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 import os
-from core.config import load_config
+from config import load_config
 
 
 def test_load_node_config(tmp_path, monkeypatch):

--- a/worker/main.py
+++ b/worker/main.py
@@ -10,7 +10,7 @@ import logging
 import asyncio
 import requests
 from core.telemetry import setup_telemetry
-from core.config import load_config
+from config import load_config
 from core.log_utils import configure_logging
 from core.async_runner import AsyncRunner
 


### PR DESCRIPTION
## Summary
- provide repo-level `config.load_config`
- use centralized config in broker, worker, and orchestrator
- document configuration helper in README
- adjust telemetry to allow missing OTLP exporter
- update tests to import new config module

## Testing
- `OTEL_SDK_DISABLED=true pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686df7548e20832aacca86142f815202