### PR TITLE
Finalize Grafana GitOps docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,14 @@ OpenTelemetry endpoint configured in `core/telemetry.py`.
 Community health metrics are available via the CHAOSS dashboard described in
 [chaoss/README.md](chaoss/README.md).
 
+### Grafana Dashboards as Code
+
+Dashboard JSON files reside in [grafana/dashboards](grafana/dashboards). Pushing
+changes to this directory triggers the *Grafana Deploy* workflow, which runs
+`scripts/apply_dashboards.py` to apply the dashboards to Grafana using the
+`GRAFANA_URL` and `GRAFANA_API_KEY` secrets. See
+[docs/grafana_gitops.md](docs/grafana_gitops.md) for details.
+
 ### Example usage
 
 Run the services directly with overrides:

--- a/docs/grafana_gitops.md
+++ b/docs/grafana_gitops.md
@@ -3,11 +3,14 @@
 Dashboards for AI-SWA are managed as code and deployed automatically.
 
 1. Run `python scripts/update_dashboards.py` to generate JSON files under
-   `grafana/dashboards/`.
-2. Commit the JSON files to version control. Any change to this directory triggers
-   the `Grafana Deploy` workflow which applies the dashboards to the configured
-   Grafana instance via its HTTP API.
-3. Provide `GRAFANA_URL` and `GRAFANA_API_KEY` as repository secrets so the
+   `grafana/dashboards/`. This directory is dedicated solely to dashboard
+   definitions.
+2. Commit the JSON files to version control. Any modification inside
+   `grafana/dashboards/` triggers the `Grafana Deploy` workflow defined at
+   `.github/workflows/grafana.yml`.
+3. The workflow installs dependencies and runs `python scripts/apply_dashboards.py`
+   to post each dashboard to the configured Grafana instance via its HTTP API.
+4. Provide `GRAFANA_URL` and `GRAFANA_API_KEY` as repository secrets so the
    workflow can authenticate.
 
 This approach keeps Grafana configuration fully declarative and reproducible.

--- a/tasks.yml
+++ b/tasks.yml
@@ -1291,7 +1291,7 @@
     - Editing a dashboard JSON in Git updates Grafana automatically.
     - Grafana dashboards and data sources are fully declarative.
   priority: 2
-  status: pending
+  status: done
   epic: Observability
 
 - id: 160


### PR DESCRIPTION
## Summary
- mark OBS-03 dashboard GitOps task as complete
- document Grafana GitOps flow in README
- expand grafana_gitops.md with workflow details

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_686e0487e008832a871f5490ed0ffb2e