### PR TITLE
Add RL training metrics export

### DIFF
--- a/docs/grafana_gitops.md
+++ b/docs/grafana_gitops.md
@@ -11,6 +11,15 @@ Dashboards for AI-SWA are managed as code and deployed automatically.
 3. The workflow installs dependencies and runs `python scripts/apply_dashboards.py`
    to post each dashboard to the configured Grafana instance via its HTTP API.
 4. Provide `GRAFANA_URL` and `GRAFANA_API_KEY` as repository secrets so the
-   workflow can authenticate.
+ workflow can authenticate.
 
 This approach keeps Grafana configuration fully declarative and reproducible.
+
+## RL Training Dashboard
+
+The training scripts expose Prometheus metrics `rl_training_reward` and
+`rl_training_episode_length`. Running `RLTrainer` with a non-zero
+`metrics_port` starts a metrics endpoint (default `9200`).
+
+Generate the dashboard JSON and commit `grafana/dashboards/rl_training.json` to
+visualize these values in Grafana.

--- a/grafana/dashboards/rl_training.json
+++ b/grafana/dashboards/rl_training.json
@@ -1,0 +1,325 @@
+{
+  "__inputs": [],
+  "annotations": {
+    "list": []
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "panels": [],
+  "refresh": "10s",
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 1,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rl_training_reward",
+              "query": "rl_training_reward",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "reward",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Episode Reward",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 2,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "rl_training_episode_length",
+              "query": "rl_training_episode_length",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "steps",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Episode Length",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        }
+      ],
+      "showTitle": false,
+      "title": "New row",
+      "repeat": null
+    }
+  ],
+  "schemaVersion": 12,
+  "sharedCrosshair": false,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "title": "RL Training Metrics",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "nowDelay": null,
+    "hidden": false
+  },
+  "timezone": "utc",
+  "version": 0,
+  "uid": null
+}

--- a/grafana/rl_training_dashboard.py
+++ b/grafana/rl_training_dashboard.py
@@ -1,0 +1,25 @@
+from grafanalib.core import Dashboard, Graph, Row, Target
+
+RL_TRAINING_DASHBOARD = Dashboard(
+    title="RL Training Metrics",
+    rows=[
+        Row(panels=[
+            Graph(
+                title="Episode Reward",
+                dataSource="Prometheus",
+                targets=[Target(expr="rl_training_reward", legendFormat="reward")],
+            ),
+            Graph(
+                title="Episode Length",
+                dataSource="Prometheus",
+                targets=[Target(expr="rl_training_episode_length", legendFormat="steps")],
+            ),
+        ])
+    ],
+).auto_panel_ids()
+
+if __name__ == "__main__":
+    import json
+    from grafanalib._gen import DashboardEncoder
+
+    print(json.dumps(RL_TRAINING_DASHBOARD.to_json_data(), indent=2, cls=DashboardEncoder))

--- a/scripts/update_dashboards.py
+++ b/scripts/update_dashboards.py
@@ -6,6 +6,7 @@ from grafanalib._gen import DashboardEncoder
 
 from grafana.dashboard import DASHBOARD
 from grafana.observer_dashboard import OBSERVER_DASHBOARD
+from grafana.rl_training_dashboard import RL_TRAINING_DASHBOARD
 
 
 def write_dashboard(obj, path: Path) -> None:
@@ -19,6 +20,7 @@ def main() -> None:
     OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
     write_dashboard(DASHBOARD, OUTPUT_DIR / "improvement-dashboard.json")
     write_dashboard(OBSERVER_DASHBOARD, OUTPUT_DIR / "observer-dashboard.json")
+    write_dashboard(RL_TRAINING_DASHBOARD, OUTPUT_DIR / "rl_training.json")
     print("Dashboards updated")
 
 

--- a/vision/training.py
+++ b/vision/training.py
@@ -2,10 +2,15 @@ from __future__ import annotations
 
 """Simple RL training pipeline for the Vision Engine."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+from prometheus_client import Gauge, start_http_server
 
 from core.observability import MetricsProvider
 from .vision_engine import RLAgent
+
+REWARD_GAUGE = Gauge("rl_training_reward", "Reward for the last episode")
+LENGTH_GAUGE = Gauge("rl_training_episode_length", "Steps in the last episode")
 
 
 @dataclass
@@ -14,8 +19,16 @@ class RLTrainer:
 
     agent: RLAgent
     metrics_provider: MetricsProvider
+    metrics_port: int = 0
+    _server_started: bool = field(default=False, init=False, repr=False)
 
-    def run(self) -> None:
+    def run(self, episodes: int = 1) -> None:
         """Collect metrics and pass them to the agent's training routine."""
-        metrics = self.metrics_provider.collect()
-        self.agent.train(metrics)
+        if self.metrics_port and not self._server_started:
+            start_http_server(self.metrics_port)
+            self._server_started = True
+        for _ in range(episodes):
+            metrics = self.metrics_provider.collect()
+            reward = self.agent.train(metrics)
+            REWARD_GAUGE.set(reward)
+            LENGTH_GAUGE.set(len(metrics))

--- a/vision/vision_engine.py
+++ b/vision/vision_engine.py
@@ -83,12 +83,16 @@ class RLAgent:
             with self.history_path.open("a", encoding="utf-8") as f:
                 f.write(json.dumps(entry) + "\n")
 
-    def train(self, metrics: Dict[str, float]) -> None:
-        """Collect ``metrics`` for offline training."""
+    def train(self, metrics: Dict[str, float]) -> float:
+        """Collect ``metrics`` for offline training and return reward."""
+        reward = sum(
+            v for v in metrics.values() if isinstance(v, (int, float))
+        )
         self.training_data.append(metrics)
         if self.training_path:
             with self.training_path.open("a", encoding="utf-8") as f:
                 f.write(json.dumps(metrics) + "\n")
+        return float(reward)
 
     def update_authority(self, performance_gain: float, threshold: float = 0.05) -> None:
         """Increase authority when ``performance_gain`` exceeds ``threshold``."""


### PR DESCRIPTION
## Summary
- expose RL training metrics via `prometheus_client`
- generate new `rl_training.json` dashboard
- document RL dashboard setup

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e182303b8832a8a6e8228e7c99f11