### PR TITLE
Add npm audit check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,15 @@ EOF
         with:
           name: pip-audit-report
           path: pip-audit.json
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Run npm audit for Node services
+        working-directory: services/node
+        run: |
+          npm ci --omit=dev
+          npm audit --production --audit-level=high
       - name: Build Docker images
         run: docker compose -f docker-compose.yml build
       - name: Test plugin marketplace container

--- a/docs/ci/README.md
+++ b/docs/ci/README.md
@@ -1,0 +1,16 @@
+# Continuous Integration Overview
+
+This repository uses GitHub Actions to enforce quality gates on every commit. The workflow performs dependency audits, linting, tests, and security scans.
+
+## Node Security Check
+
+Node-based services run an additional step that installs dependencies and executes `npm audit --production`. The audit fails the build if any vulnerabilities of **high** severity or greater are reported.
+
+Run the check locally from the project root:
+
+```bash
+cd services/node
+npm ci --omit=dev
+npm audit --production --audit-level=high
+```
+


### PR DESCRIPTION
## Summary
- check Node dependencies in `services/node` using `npm audit --production`
- document the audit step in CI docs

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e1aef1440832ab60cf3751ae25249