### PR TITLE
Add governance board docs and agenda template

### DIFF
--- a/.github/ISSUE_TEMPLATE/agenda-item.yml
+++ b/.github/ISSUE_TEMPLATE/agenda-item.yml
@@ -1,0 +1,29 @@
+name: Governance Board Agenda Item
+description: Submit a topic for discussion at the next governance board meeting.
+title: "[Agenda]: "
+labels: [governance, agenda]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please provide a concise summary of the agenda item. Include any links or background information necessary for board members to prepare.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What should the board discuss?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Optional background, links, or references.
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options:
+        - High
+        - Medium
+        - Low

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -2,6 +2,8 @@
 
 SelfArchitectAI follows the **Liberal Contribution** model. Maintainers guide the project's direction while welcoming community input.
 
+For details on board membership and how meetings are run, see [docs/community/governance_board.md](docs/community/governance_board.md).
+
 ## Maintainers
 - Responsible for reviewing contributions and ensuring project health.
 - New maintainers are nominated by the existing team and accepted by lazy consensus.

--- a/docs/community/governance_board.md
+++ b/docs/community/governance_board.md
@@ -1,0 +1,17 @@
+# Governance Board
+
+This document outlines the structure and operating procedures of the SelfArchitectAI governance board.
+
+## Board Roles
+- **Chair** – Facilitates meetings and ensures agenda items are addressed.
+- **Secretary** – Records minutes and tracks action items.
+- **Maintainer Representatives** – Speak on behalf of active maintainers.
+- **Community Representatives** – Bring feedback from contributors and users.
+
+## Meeting Cadence
+The board meets bi‑weekly via video conference. Agendas are published at least 48 hours in advance. Minutes are posted to the repository within one week after each meeting.
+
+## Decision Making
+Decisions are made by consensus whenever possible. When consensus cannot be reached, a simple majority vote of attending members decides the outcome. Quorum is defined as half of all active board members.
+
+Agenda proposals should be filed using the [agenda item issue template](../../.github/ISSUE_TEMPLATE/agenda-item.yml).


### PR DESCRIPTION
## Summary
- describe governance board roles and process in new community docs
- reference board details from GOVERNANCE.md
- add GitHub issue template for agenda item submissions

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e1da4365c832aa659e1fc2d506f8a