### PR TITLE
Add agent beta test report and follow-up tasks

### DIFF
--- a/docs/reports/agent_beta_test.md
+++ b/docs/reports/agent_beta_test.md
@@ -1,0 +1,49 @@
+# Agent Beta Test Report
+
+This report summarizes a test run of the orchestrator and active agents after task 207. At the time of testing only **SWA-CORE-01** is active. The proposed QA and Docs agents from task 207 are not yet implemented.
+
+## Environment
+- Python version: Python 3.12.10
+- Task queue length: 129
+- Active agents:
+```
+SWA-CORE-01
+```
+
+## Test Run
+The orchestrator was executed using:
+```bash
+python -m ai_swa.orchestrator _run --config config.yaml -v
+```
+Partial log output:
+```
+{
+    "body": "Orchestrator running",
+    "severity_number": 9,
+    "severity_text": "INFO",
+    "attributes": {
+...
+            "service.name": "ai_swa"
+        },
+        "schema_url": ""
+    }
+}
+```
+
+The run produced frequent `AttributeError` messages originating from `self_auditor.py`.
+
+## Pytest Results
+```
+.ss.........................s.................s............s............ [ 41%]
+..s..................................................................... [ 82%]
+..............................                                           [100%]
+168 passed, 6 skipped, 23 warnings in 40.36s
+```
+
+## Observations
+- The orchestrator executed multiple tasks but failed during the self-auditor stage.
+- The missing QA and Docs agents mean the system does not yet run security or documentation checks.
+
+## Follow-up Issues
+- Implement agents SWA-QA-01 and SWA-DOCS-01 as described in task 207.
+- Investigate the `AttributeError` in `self_auditor.py`.

--- a/tasks.yml
+++ b/tasks.yml
@@ -2122,3 +2122,30 @@
     - "Every documentation page has at least two methods for providing feedback."
     - "Feedback is routed to a designated Slack channel or ticketing system."
   assigned_to: null
+- id: 218
+  description: Implement SWA-QA-01 and SWA-DOCS-01 agents so that commits with 'bug' or 'docs' labels trigger automated QA and documentation checks.
+  dependencies: []
+  priority: 2
+  status: pending
+  area: core
+  actionable_steps:
+    - Develop the QA agent with Bandit integration and static analysis tooling.
+    - Develop the Documentation agent to verify code comments and docstrings.
+    - Update the supervisor to delegate tasks based on commit labels.
+  acceptance_criteria:
+    - Pull requests labeled 'bug' or 'docs' run the corresponding agent.
+    - Output from the agents is logged in the reports directory.
+  epic: Agent Implementation
+- id: 219
+  description: Fix AttributeError in self_auditor.py when auditing Python classes during orchestrator runs.
+  dependencies: []
+  priority: 3
+  status: pending
+  area: testing
+  actionable_steps:
+    - Reproduce the error with the current task queue.
+    - Add unit tests covering class analysis in the self auditor.
+    - Update the code to handle class nodes correctly.
+  acceptance_criteria:
+    - Orchestrator runs without AttributeError from self_auditor.
+  epic: Testing Improvements


### PR DESCRIPTION
## Summary
- run orchestrator and capture logs in `agent_beta_test.md`
- add follow-up tasks for QA/DOCS agents and self-auditor bug

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e202c7dfc832a9acbb97f364b886d