### PR TITLE
Add plugin CLI for packaging and signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,24 @@ and is verified when `PLUGIN_SIGNING_KEY` is set. See
 [`docs/plugins/api.md`](docs/plugins/api.md) for plugin API details and
 isolation requirements.
 
+### Plugin CLI
+
+`plugins/cli.py` provides commands for common plugin tasks:
+
+```bash
+# validate manifest
+python plugins/cli.py validate plugins/example_plugin
+
+# create dist/example-0.1.0.zip
+python plugins/cli.py package plugins/example_plugin
+
+# sign the archive with cosign
+python plugins/cli.py sign dist/example-0.1.0.zip --key cosign.key --password $COSIGN_PASSWORD
+
+# publish to the local marketplace
+python plugins/cli.py upload plugins/example_plugin
+```
+
 ### Security CI Pipeline
 
 The CI workflow performs automated security checks on every push:

--- a/plugins/cli.py
+++ b/plugins/cli.py
@@ -1,0 +1,75 @@
+import argparse
+import subprocess
+from pathlib import Path
+
+from core.plugins import load_manifest
+from scripts.package_plugin import create_plugin_archive
+from services.plugin_marketplace import pipeline
+
+
+def _cmd_validate(args: argparse.Namespace) -> None:
+    manifest = load_manifest(Path(args.plugin) / "manifest.json")
+    print(f"Manifest for '{manifest.id}' version {manifest.version} is valid")
+
+
+def _cmd_package(args: argparse.Namespace) -> None:
+    archive = create_plugin_archive(Path(args.plugin))
+    print(f"Created archive at {archive}")
+
+
+def _cmd_sign(args: argparse.Namespace) -> None:
+    archive = Path(args.archive)
+    sig_path = archive.with_suffix(archive.suffix + ".sig")
+    env = {"COSIGN_EXPERIMENTAL": "1"}
+    if args.password:
+        env["COSIGN_PASSWORD"] = args.password
+    cmd = [
+        "cosign",
+        "sign-blob",
+        "--key",
+        args.key,
+        str(archive),
+    ]
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
+    sig_path.write_text(result.stdout)
+    print(f"Signature written to {sig_path}")
+
+
+def _cmd_upload(args: argparse.Namespace) -> None:
+    pipeline.certify_and_publish(Path(args.plugin))
+    print("Plugin published to marketplace")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Plugin management utilities")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    validate_p = sub.add_parser("validate", help="Validate plugin manifest")
+    validate_p.add_argument("plugin", help="Path to plugin directory")
+    validate_p.set_defaults(func=_cmd_validate)
+
+    package_p = sub.add_parser("package", help="Create plugin archive")
+    package_p.add_argument("plugin", help="Path to plugin directory")
+    package_p.set_defaults(func=_cmd_package)
+
+    sign_p = sub.add_parser("sign", help="Sign plugin archive with cosign")
+    sign_p.add_argument("archive", help="Path to plugin archive")
+    sign_p.add_argument("--key", required=True, help="Path to cosign key")
+    sign_p.add_argument("--password", help="cosign key password")
+    sign_p.set_defaults(func=_cmd_sign)
+
+    upload_p = sub.add_parser("upload", help="Upload plugin to marketplace")
+    upload_p.add_argument("plugin", help="Path to plugin directory")
+    upload_p.set_defaults(func=_cmd_upload)
+
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- convert package script into a CLI at `plugins/cli.py`
- document how to validate, package, sign and upload plugins

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e2494cf74832a9c3b8553c1183072