### PR TITLE
Add plugin dependency tracking

### DIFF
--- a/core/plugins.py
+++ b/core/plugins.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, asdict, field
 from pathlib import Path
 from typing import List
 
@@ -33,6 +33,8 @@ class PluginManifest:
     name: str
     version: str
     permissions: List[str]
+    dependencies: list[str] = field(default_factory=list)
+    compatibility: str | None = None
     signature: str | None = None
 
     def data_for_signature(self) -> dict:

--- a/plugins/cli.py
+++ b/plugins/cli.py
@@ -13,6 +13,8 @@ def _cmd_validate(args: argparse.Namespace) -> None:
 
 
 def _cmd_package(args: argparse.Namespace) -> None:
+    # Validate manifest before packaging
+    load_manifest(Path(args.plugin) / "manifest.json")
     archive = create_plugin_archive(Path(args.plugin))
     print(f"Created archive at {archive}")
 

--- a/plugins/example_plugin/manifest.json
+++ b/plugins/example_plugin/manifest.json
@@ -2,5 +2,7 @@
   "id": "example",
   "name": "Example Plugin",
   "version": "0.1.0",
-  "permissions": ["read_files"]
+  "permissions": ["read_files"],
+  "dependencies": [],
+  "compatibility": ">=0.1"
 }

--- a/plugins/manifest_schema.json
+++ b/plugins/manifest_schema.json
@@ -9,6 +9,11 @@
       "type": "array",
       "items": {"type": "string"}
     },
+    "dependencies": {
+      "type": "array",
+      "items": {"type": "string"}
+    },
+    "compatibility": {"type": "string"},
     "signature": {"type": "string"}
   },
   "required": ["id", "name", "version", "permissions"],

--- a/plugins/tech_debt_analyzer/manifest.json
+++ b/plugins/tech_debt_analyzer/manifest.json
@@ -2,5 +2,7 @@
   "id": "techdebt",
   "name": "Tech Debt Analyzer",
   "version": "0.1.0",
-  "permissions": ["read_files"]
+  "permissions": ["read_files"],
+  "dependencies": [],
+  "compatibility": ">=0.1"
 }

--- a/services/plugin_marketplace/pipeline.py
+++ b/services/plugin_marketplace/pipeline.py
@@ -34,4 +34,10 @@ def certify_and_publish(plugin_dir: Path) -> None:
     dest = Path(PLUGIN_DIR) / archive.name
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(archive, dest)
-    add_plugin(manifest.id, manifest.name, manifest.version, dest.name)
+    add_plugin(
+        manifest.id,
+        manifest.name,
+        manifest.version,
+        manifest.dependencies,
+        dest.name,
+    )

--- a/services/plugin_marketplace/service.py
+++ b/services/plugin_marketplace/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sqlite3
+import json
 from pathlib import Path
 
 import grpc
@@ -29,17 +30,17 @@ def get_db():
 def init_db() -> None:
     conn = get_db()
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS plugins (id TEXT PRIMARY KEY, name TEXT, version TEXT, path TEXT)"
+        "CREATE TABLE IF NOT EXISTS plugins (id TEXT PRIMARY KEY, name TEXT, version TEXT, dependencies TEXT, path TEXT)"
     )
     conn.commit()
     conn.close()
 
 
-def add_plugin(id: str, name: str, version: str, path: str) -> None:
+def add_plugin(id: str, name: str, version: str, dependencies: list[str], path: str) -> None:
     conn = get_db()
     conn.execute(
-        "INSERT OR REPLACE INTO plugins (id, name, version, path) VALUES (?, ?, ?, ?)",
-        (id, name, version, path),
+        "INSERT OR REPLACE INTO plugins (id, name, version, dependencies, path) VALUES (?, ?, ?, ?, ?)",
+        (id, name, version, json.dumps(dependencies), path),
     )
     conn.commit()
     conn.close()
@@ -47,7 +48,7 @@ def add_plugin(id: str, name: str, version: str, path: str) -> None:
 
 def list_plugins_from_db() -> list[dict[str, str]]:
     conn = get_db()
-    rows = conn.execute("SELECT id, name, version, path FROM plugins").fetchall()
+    rows = conn.execute("SELECT id, name, version, dependencies, path FROM plugins").fetchall()
     conn.close()
     return [dict(row) for row in rows]
 

--- a/tests/integration/test_plugin_marketplace.py
+++ b/tests/integration/test_plugin_marketplace.py
@@ -36,6 +36,8 @@ def _make_plugin(tmp_path: Path, plugin_id: str, fail_scan=False) -> Path:
         "name": plugin_id.title(),
         "version": "0.1.0",
         "permissions": ["read_files"],
+        "dependencies": [],
+        "compatibility": ">=0.1",
     }
     (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
     code = "def run():\n    return 'ok'\n"

--- a/tests/test_plugin_marketplace_service.py
+++ b/tests/test_plugin_marketplace_service.py
@@ -20,7 +20,7 @@ def setup_module(module):
     module.svc = reload(svc)
     svc.init_db()
     # insert sample plugin
-    svc.add_plugin("demo", "Demo", "0.1.0", "demo.zip")
+    svc.add_plugin("demo", "Demo", "0.1.0", [], "demo.zip")
     (tmp / "demo.zip").write_bytes(b"demo")
 
 

--- a/tests/test_plugin_security.py
+++ b/tests/test_plugin_security.py
@@ -24,6 +24,8 @@ def test_load_valid_manifest(tmp_path):
         "name": "Demo Plugin",
         "version": "0.1",
         "permissions": ["read_files"],
+        "dependencies": [],
+        "compatibility": ">=0.1",
     }
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps({**data, "signature": sign(data, key)}))
@@ -38,6 +40,8 @@ def test_reject_invalid_permission(tmp_path):
         "name": "Demo Plugin",
         "version": "0.1",
         "permissions": ["dangerous"],
+        "dependencies": [],
+        "compatibility": ">=0.1",
     }
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(data))
@@ -53,6 +57,8 @@ def test_reject_invalid_signature(tmp_path):
         "name": "Demo Plugin",
         "version": "0.1",
         "permissions": ["read_files"],
+        "dependencies": [],
+        "compatibility": ">=0.1",
         "signature": "bad",
     }
     manifest_path = tmp_path / "manifest.json"
@@ -80,6 +86,8 @@ def test_policy_rejects_disallowed_permissions(tmp_path, monkeypatch):
         "name": "Demo Plugin",
         "version": "0.1",
         "permissions": ["network"],
+        "dependencies": [],
+        "compatibility": ">=0.1",
     }
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(data))
@@ -96,6 +104,8 @@ def test_policy_rejects_unknown_plugin(tmp_path, monkeypatch):
         "name": "Bar Plugin",
         "version": "0.1",
         "permissions": ["read_files"],
+        "dependencies": [],
+        "compatibility": ">=0.1",
     }
     manifest_path = tmp_path / "manifest.json"
     manifest_path.write_text(json.dumps(data))


### PR DESCRIPTION
## Summary
- extend plugin manifest schema with `dependencies` and `compatibility`
- validate manifest before packaging via CLI
- store plugin dependencies in the marketplace DB
- include new fields in example manifests
- adjust tests for updated schema

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e265db15c832aa1fbf2cee602808b