### PR TITLE
Add plugin marketplace metrics and dashboard

### DIFF
--- a/grafana/dashboards/plugin_marketplace.json
+++ b/grafana/dashboards/plugin_marketplace.json
@@ -1,0 +1,325 @@
+{
+  "__inputs": [],
+  "annotations": {
+    "list": []
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "panels": [],
+  "refresh": "10s",
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 1,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "plugin_downloads_total",
+              "query": "plugin_downloads_total",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "downloads",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Plugin Downloads",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 2,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 6,
+          "targets": [
+            {
+              "expr": "plugin_download_errors_total",
+              "query": "plugin_download_errors_total",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "errors",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Download Errors",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        }
+      ],
+      "showTitle": false,
+      "title": "New row",
+      "repeat": null
+    }
+  ],
+  "schemaVersion": 12,
+  "sharedCrosshair": false,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "title": "Plugin Marketplace",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "nowDelay": null,
+    "hidden": false
+  },
+  "timezone": "utc",
+  "version": 0,
+  "uid": null
+}

--- a/services/plugin_marketplace/metrics.py
+++ b/services/plugin_marketplace/metrics.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+"""Prometheus metrics for the plugin marketplace service."""
+
+try:
+    from opentelemetry import metrics
+except Exception:  # pragma: no cover - optional dependency
+    metrics = None
+
+if metrics:
+    _meter = metrics.get_meter_provider().get_meter(__name__)
+    DOWNLOADS = _meter.create_counter(
+        "plugin_downloads_total",
+        description="Number of plugin downloads",
+    )
+    ERRORS = _meter.create_counter(
+        "plugin_download_errors_total",
+        description="Number of failed download attempts",
+    )
+else:  # pragma: no cover - telemetry optional
+    DOWNLOADS = None
+    ERRORS = None


### PR DESCRIPTION
## Summary
- expose Prometheus counters for plugin downloads and errors
- start telemetry in plugin marketplace service
- record metrics on REST and gRPC download endpoints
- add Grafana dashboard for plugin marketplace
- test metrics endpoint

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e35280288832ab90a2e7ace7be5eb