### PR TITLE
Add Sentry integration

### DIFF
--- a/broker/main.py
+++ b/broker/main.py
@@ -14,7 +14,9 @@ worker output.
 """
 
 import logging
+import os
 import sqlite3
+import sentry_sdk
 from fastapi import FastAPI, HTTPException, Depends, Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -32,6 +34,7 @@ from core.log_utils import configure_logging
 
 config = load_config()
 DB_PATH = config["broker"]["db_path"]
+sentry_sdk.init(dsn=os.getenv("SENTRY_DSN"))
 configure_logging()
 logger = logging.getLogger(__name__)
 

--- a/core/bootstrap.py
+++ b/core/bootstrap.py
@@ -2,7 +2,9 @@
 
 import json
 import logging
+import os
 import sys
+import sentry_sdk
 from datetime import datetime
 from pathlib import Path
 
@@ -109,6 +111,7 @@ def load_schema_and_tasks(path: Path):
 
 def main():
     """Bootstrap the system by validating ``tasks.yml``."""
+    sentry_sdk.init(dsn=os.getenv("SENTRY_DSN"))
     setup_logging()
     schema, tasks = load_schema_and_tasks(Path("tasks.yml"))
 

--- a/docs/observability/sentry.md
+++ b/docs/observability/sentry.md
@@ -1,0 +1,15 @@
+# Sentry Error Monitoring
+
+SelfArchitectAI services can report runtime errors to Sentry. Set the `SENTRY_DSN` environment variable for each service to enable the integration.
+
+## Setup
+
+1. Install dependencies via `pip install -r requirements.lock`.
+2. Provide your project DSN in `SENTRY_DSN` for `core/bootstrap.py`, `broker/main.py` and `worker/main.py`.
+3. Start the services as usual. If the variable is unset, Sentry is disabled.
+
+Example:
+```bash
+export SENTRY_DSN=https://<key>@sentry.io/<project>
+python core/bootstrap.py
+```

--- a/requirements.lock
+++ b/requirements.lock
@@ -28,6 +28,7 @@ certifi==2025.6.15
     #   httpcore
     #   httpx
     #   requests
+    #   sentry-sdk
 charset-normalizer==3.4.2
     # via requests
 click==8.2.1
@@ -193,6 +194,8 @@ rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
+sentry-sdk==2.32.0
+    # via -r requirements.txt
 six==1.17.0
     # via mando
 smmap==5.0.2
@@ -233,7 +236,9 @@ typing-extensions==4.14.0
 typing-inspection==0.4.1
     # via pydantic
 urllib3==2.5.0
-    # via requests
+    # via
+    #   requests
+    #   sentry-sdk
 uvicorn==0.35.0
     # via -r requirements.txt
 wily==1.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ grafanalib==0.7.1  # grafana dashboards as code
 opentelemetry-exporter-otlp-proto-grpc==1.34.1  # OTLP exporter
 protobuf>=5.0,<6.0
 ariadne==0.26.2
+sentry-sdk==2.32.0

--- a/worker/main.py
+++ b/worker/main.py
@@ -7,8 +7,10 @@ next available task via ``/tasks/next``. Each task may provide a shell
 """
 
 import logging
+import os
 import asyncio
 import requests
+import sentry_sdk
 from core.telemetry import setup_telemetry
 from config import load_config
 from core.log_utils import configure_logging
@@ -17,6 +19,7 @@ from core.async_runner import AsyncRunner
 config = load_config()
 BROKER_URL = config["worker"]["broker_url"]
 CONCURRENCY = int(config["worker"].get("concurrency", 2))
+sentry_sdk.init(dsn=os.getenv("SENTRY_DSN"))
 setup_telemetry(
     service_name="worker",
     metrics_port=int(config["worker"]["metrics_port"]),


### PR DESCRIPTION
## Summary
- add `sentry-sdk` dependency
- initialize Sentry in bootstrap and services
- document Sentry setup

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e38d97800832a83ca8f1d3d92ed85