### PR TITLE
Add Helm deployment charts

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: ai-swa
+version: 0.1.0
+appVersion: "0.1.0"
+dependencies:
+  - name: orchestrator
+    version: 0.1.0
+    repository: "file://orchestrator"
+  - name: worker
+    version: 0.1.0
+    repository: "file://worker"
+  - name: broker
+    version: 0.1.0
+    repository: "file://broker"
+  - name: plugin-marketplace
+    version: 0.1.0
+    repository: "file://plugin-marketplace"

--- a/deploy/helm/broker/Chart.yaml
+++ b/deploy/helm/broker/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: broker
+description: AI-SWA broker service
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/helm/broker/templates/_helpers.tpl
+++ b/deploy/helm/broker/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "broker.name" -}}
+{{- default .Chart.Name .Values.nameOverride -}}
+{{- end -}}
+
+{{- define "broker.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride -}}
+{{- else -}}
+{{ printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/broker/templates/deployment.yaml
+++ b/deploy/helm/broker/templates/deployment.yaml
@@ -1,0 +1,25 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "broker.fullname" . }}
+  labels:
+    app: {{ include "broker.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "broker.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "broker.name" . }}
+    spec:
+      containers:
+        - name: broker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: DB_PATH
+              value: {{ .Values.env.DB_PATH | quote }}
+          ports:
+            - containerPort: {{ .Values.service.port }}

--- a/deploy/helm/broker/templates/service.yaml
+++ b/deploy/helm/broker/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "broker.fullname" . }}
+  labels:
+    app: {{ include "broker.name" . }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ include "broker.name" . }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+      protocol: TCP
+      name: http

--- a/deploy/helm/broker/values.yaml
+++ b/deploy/helm/broker/values.yaml
@@ -1,0 +1,10 @@
+replicaCount: 1
+image:
+  repository: ai-swa/broker
+  tag: "latest"
+  pullPolicy: IfNotPresent
+env:
+  DB_PATH: /data/tasks.db
+service:
+  type: ClusterIP
+  port: 8000

--- a/deploy/helm/orchestrator/Chart.yaml
+++ b/deploy/helm/orchestrator/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: orchestrator
+description: AI-SWA orchestrator service
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/helm/orchestrator/templates/_helpers.tpl
+++ b/deploy/helm/orchestrator/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "orchestrator.name" -}}
+{{- default .Chart.Name .Values.nameOverride -}}
+{{- end -}}
+
+{{- define "orchestrator.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride -}}
+{{- else -}}
+{{ printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/orchestrator/templates/deployment.yaml
+++ b/deploy/helm/orchestrator/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "orchestrator.fullname" . }}
+  labels:
+    app: {{ include "orchestrator.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "orchestrator.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "orchestrator.name" . }}
+    spec:
+      containers:
+        - name: orchestrator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: BROKER_URL
+              value: {{ .Values.env.BROKER_URL | quote }}

--- a/deploy/helm/orchestrator/values.yaml
+++ b/deploy/helm/orchestrator/values.yaml
@@ -1,0 +1,7 @@
+replicaCount: 1
+image:
+  repository: ai-swa/orchestrator
+  tag: "latest"
+  pullPolicy: IfNotPresent
+env:
+  BROKER_URL: http://broker:8000

--- a/deploy/helm/plugin-marketplace/Chart.yaml
+++ b/deploy/helm/plugin-marketplace/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: plugin-marketplace
+description: AI-SWA plugin marketplace
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/helm/plugin-marketplace/templates/_helpers.tpl
+++ b/deploy/helm/plugin-marketplace/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "plugin-marketplace.name" -}}
+{{- default .Chart.Name .Values.nameOverride -}}
+{{- end -}}
+
+{{- define "plugin-marketplace.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride -}}
+{{- else -}}
+{{ printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/plugin-marketplace/templates/deployment.yaml
+++ b/deploy/helm/plugin-marketplace/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "plugin-marketplace.fullname" . }}
+  labels:
+    app: {{ include "plugin-marketplace.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "plugin-marketplace.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "plugin-marketplace.name" . }}
+    spec:
+      containers:
+        - name: plugin-marketplace
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.httpPort }}
+            - containerPort: {{ .Values.service.grpcPort }}

--- a/deploy/helm/plugin-marketplace/templates/service.yaml
+++ b/deploy/helm/plugin-marketplace/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "plugin-marketplace.fullname" . }}
+  labels:
+    app: {{ include "plugin-marketplace.name" . }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    app: {{ include "plugin-marketplace.name" . }}
+  ports:
+    - port: {{ .Values.service.httpPort }}
+      targetPort: {{ .Values.service.httpPort }}
+      protocol: TCP
+      name: http
+    - port: {{ .Values.service.grpcPort }}
+      targetPort: {{ .Values.service.grpcPort }}
+      protocol: TCP
+      name: grpc

--- a/deploy/helm/plugin-marketplace/values.yaml
+++ b/deploy/helm/plugin-marketplace/values.yaml
@@ -1,0 +1,9 @@
+replicaCount: 1
+image:
+  repository: ai-swa/plugin-marketplace
+  tag: "latest"
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  httpPort: 8003
+  grpcPort: 50052

--- a/deploy/helm/values-dev.yaml
+++ b/deploy/helm/values-dev.yaml
@@ -1,0 +1,16 @@
+orchestrator:
+  replicaCount: 1
+  image:
+    tag: "latest"
+worker:
+  replicaCount: 1
+  image:
+    tag: "latest"
+broker:
+  replicaCount: 1
+  image:
+    tag: "latest"
+plugin-marketplace:
+  replicaCount: 1
+  image:
+    tag: "latest"

--- a/deploy/helm/values-prod.yaml
+++ b/deploy/helm/values-prod.yaml
@@ -1,0 +1,16 @@
+orchestrator:
+  replicaCount: 2
+  image:
+    tag: "stable"
+worker:
+  replicaCount: 2
+  image:
+    tag: "stable"
+broker:
+  replicaCount: 2
+  image:
+    tag: "stable"
+plugin-marketplace:
+  replicaCount: 2
+  image:
+    tag: "stable"

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,4 @@
+orchestrator: {}
+worker: {}
+broker: {}
+plugin-marketplace: {}

--- a/deploy/helm/worker/Chart.yaml
+++ b/deploy/helm/worker/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: worker
+description: AI-SWA worker service
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/helm/worker/templates/_helpers.tpl
+++ b/deploy/helm/worker/templates/_helpers.tpl
@@ -1,0 +1,12 @@
+{{- define "worker.name" -}}
+{{- default .Chart.Name .Values.nameOverride -}}
+{{- end -}}
+
+{{- define "worker.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride -}}
+{{- else -}}
+{{ printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/worker/templates/deployment.yaml
+++ b/deploy/helm/worker/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "worker.fullname" . }}
+  labels:
+    app: {{ include "worker.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "worker.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "worker.name" . }}
+    spec:
+      containers:
+        - name: worker
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: BROKER_URL
+              value: {{ .Values.env.BROKER_URL | quote }}

--- a/deploy/helm/worker/values.yaml
+++ b/deploy/helm/worker/values.yaml
@@ -1,0 +1,7 @@
+replicaCount: 1
+image:
+  repository: ai-swa/worker
+  tag: "latest"
+  pullPolicy: IfNotPresent
+env:
+  BROKER_URL: http://broker:8000

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -1,0 +1,34 @@
+# Deploying AI-SWA with Helm
+
+This repository ships Helm charts for running the core services on a Kubernetes cluster. The charts live under `deploy/helm/` and cover the following components:
+
+- **orchestrator** – coordinates task execution
+- **worker** – executes shell commands from the broker
+- **broker** – REST API storing tasks and results
+- **plugin-marketplace** – serves plugins over HTTP and gRPC
+
+## Basic Usage
+
+1. Ensure the container images are available to your cluster (either build and push them or use the provided tags).
+2. Choose a values file for your environment:
+   - `values-dev.yaml` – single replica of each service using the `latest` tag.
+   - `values-prod.yaml` – scaled-out deployment using the `stable` tag.
+3. Install the charts:
+
+```bash
+helm install ai-swa deploy/helm -f deploy/helm/values-dev.yaml
+```
+
+Swap in `values-prod.yaml` for a production deployment. The command installs all charts in a single release using the settings from the chosen values file.
+
+## Customization
+
+Each subchart exposes common parameters such as `image.repository`, `image.tag` and `replicaCount`. Override them on the command line or create your own values file:
+
+```bash
+helm upgrade --install ai-swa deploy/helm \
+  --set orchestrator.image.tag=v1.2.3 \
+  --set broker.service.type=LoadBalancer
+```
+
+Refer to the `values.yaml` files in each chart for the full list of options.


### PR DESCRIPTION
## Summary
- add Helm chart hierarchy for orchestrator, worker, broker and plugin marketplace
- provide development and production values files
- document how to deploy AI-SWA to Kubernetes using Helm

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e439705c8832a8c07daa3e8705235