### PR TITLE
Add RabbitMQ producer/consumer

### DIFF
--- a/broker/main.py
+++ b/broker/main.py
@@ -31,6 +31,7 @@ except Exception:  # pragma: no cover - optional dependency
 from core.security import verify_api_key, verify_token, require_role, User
 from config import load_config
 from core.log_utils import configure_logging
+from .queue import publish_task
 
 config = load_config()
 DB_PATH = config["broker"]["db_path"]
@@ -109,6 +110,10 @@ def create_task(
     conn.commit()
     task.id = cur.lastrowid
     conn.close()
+    try:
+        publish_task(task.id)
+    except Exception:  # pragma: no cover - queue optional
+        logger.warning("Failed to publish task %s to queue", task.id)
     return task
 
 

--- a/broker/queue.py
+++ b/broker/queue.py
@@ -1,0 +1,16 @@
+import os
+import pika
+
+RABBITMQ_URL = os.getenv("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
+QUEUE_NAME = os.getenv("TASK_QUEUE", "tasks")
+
+
+def publish_task(task_id: int) -> None:
+    """Publish task ID to RabbitMQ queue."""
+    params = pika.URLParameters(RABBITMQ_URL)
+    connection = pika.BlockingConnection(params)
+    channel = connection.channel()
+    channel.queue_declare(queue=QUEUE_NAME, durable=True)
+    channel.basic_publish(exchange="", routing_key=QUEUE_NAME, body=str(task_id))
+    connection.close()
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -145,6 +145,12 @@ services:
     ports:
       - "3000:3000"
 
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
 volumes:
   broker-data:
   node-data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ opentelemetry-exporter-otlp-proto-grpc==1.34.1  # OTLP exporter
 protobuf>=5.0,<6.0
 ariadne==0.26.2
 sentry-sdk==2.32.0
+pika==1.3.2

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,33 @@
+import os
+from importlib import reload
+
+from fastapi.testclient import TestClient
+
+
+def setup_module(module):
+    os.environ["DB_PATH"] = str(module.__file__ + ".db")
+    os.environ["METRICS_PORT"] = "0"
+    global broker
+    import broker.main as broker_module
+    broker = reload(broker_module)
+
+
+def test_create_task_publishes(monkeypatch, tmp_path):
+    os.environ["DB_PATH"] = str(tmp_path / "api.db")
+    os.environ["METRICS_PORT"] = "0"
+    os.environ["API_TOKENS"] = "admintoken:admin:admin"
+    broker = reload(__import__("broker.main", fromlist=["app", "init_db"]))
+
+    published: list[int] = []
+
+    def fake_publish(tid: int) -> None:
+        published.append(tid)
+
+    monkeypatch.setattr(broker, "publish_task", fake_publish)
+    client = TestClient(broker.app)
+
+    resp = client.post("/tasks", json={"description": "demo"}, headers={"Authorization": "Bearer admintoken"})
+    assert resp.status_code == 200
+    task_id = resp.json()["id"]
+    assert published == [task_id]
+    os.environ.pop("API_TOKENS")

--- a/worker/queue.py
+++ b/worker/queue.py
@@ -1,0 +1,19 @@
+import os
+import pika
+
+RABBITMQ_URL = os.getenv("RABBITMQ_URL", "amqp://guest:guest@localhost:5672/")
+QUEUE_NAME = os.getenv("TASK_QUEUE", "tasks")
+
+
+def consume(callback):
+    """Consume one message from RabbitMQ and pass payload to callback."""
+    params = pika.URLParameters(RABBITMQ_URL)
+    connection = pika.BlockingConnection(params)
+    channel = connection.channel()
+    channel.queue_declare(queue=QUEUE_NAME, durable=True)
+
+    method_frame, _, body = channel.basic_get(queue=QUEUE_NAME, auto_ack=True)
+    if method_frame:
+        callback(body.decode())
+    connection.close()
+


### PR DESCRIPTION
## Summary
- publish new tasks from the broker to RabbitMQ
- consume task ids from RabbitMQ in worker utilities
- add RabbitMQ service to docker-compose
- include pika dependency
- test publishing of tasks to RabbitMQ

## Testing
- `pytest --maxfail=1 --disable-warnings -q tests/test_broker.py`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_686e49687f58832a9affe35896673844