### PR TITLE
Add Jaeger tracing support

### DIFF
--- a/broker/main.py
+++ b/broker/main.py
@@ -41,7 +41,11 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI()
 if setup_telemetry:
-    setup_telemetry(service_name="broker", metrics_port=int(config["broker"]["metrics_port"]))
+    setup_telemetry(
+        service_name="broker",
+        metrics_port=int(config["broker"]["metrics_port"]),
+        jaeger_endpoint=config["tracing"]["jaeger_endpoint"],
+    )
 if FastAPIInstrumentor:
     FastAPIInstrumentor.instrument_app(app)
 

--- a/core/cli.py
+++ b/core/cli.py
@@ -119,7 +119,8 @@ def _check_config(path: Path) -> bool:
 def _run_orchestrator(config: Path) -> int:
     if not _check_config(config):
         return 1
-    setup_telemetry()
+    cfg = load_config()
+    setup_telemetry(jaeger_endpoint=cfg["tracing"]["jaeger_endpoint"])
     memory = Memory(Path("state.json"))
     try:
         memory.save(memory.load())

--- a/core/config.py
+++ b/core/config.py
@@ -34,6 +34,10 @@ DEFAULT_CONFIG = {
         "warning_threshold": 0.8,
         "budget_env": "PLANNER_BUDGET",
     },
+    "tracing": {
+        "jaeger_endpoint": "http://localhost:4317",
+        "endpoint_env": "JAEGER_ENDPOINT",
+    },
     "logging": {
         "config_file": "logging.conf",
         "level": "INFO",
@@ -58,6 +62,7 @@ def load_config(path: str | Path | None = None) -> dict:
         "security": {**DEFAULT_CONFIG["security"], **data.get("security", {})},
         "sandbox": {**DEFAULT_CONFIG["sandbox"], **data.get("sandbox", {})},
         "planner": {**DEFAULT_CONFIG["planner"], **data.get("planner", {})},
+        "tracing": {**DEFAULT_CONFIG["tracing"], **data.get("tracing", {})},
         "logging": {**DEFAULT_CONFIG["logging"], **data.get("logging", {})},
     }
 
@@ -115,6 +120,10 @@ def load_config(path: str | Path | None = None) -> dict:
     env_name = cfg["planner"].get("budget_env")
     if env_name and env_name in os.environ:
         cfg["planner"]["budget"] = int(os.environ[env_name])
+
+    env_name = cfg["tracing"].get("endpoint_env")
+    if env_name and env_name in os.environ:
+        cfg["tracing"]["jaeger_endpoint"] = os.environ[env_name]
 
     if "LOG_CONFIG" in os.environ:
         cfg["logging"]["config_file"] = os.environ["LOG_CONFIG"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       BROKER_METRICS_PORT: "9000"
       OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
       OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
+      JAEGER_ENDPOINT: http://jaeger:4317
     depends_on:
       - broker
       - worker
@@ -29,6 +30,7 @@ services:
       BROKER_METRICS_PORT: "9000"
       OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
       OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
+      JAEGER_ENDPOINT: http://jaeger:4317
     volumes:
       - broker-data:/data
       - ./observability/certs:/certs:ro
@@ -44,6 +46,7 @@ services:
       WORKER_METRICS_PORT: "9001"
       OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
       OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
+      JAEGER_ENDPOINT: http://jaeger:4317
     depends_on:
       - broker
     volumes:
@@ -57,6 +60,7 @@ services:
     environment:
       OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
       OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
+      JAEGER_ENDPOINT: http://jaeger:4317
     depends_on:
       - orchestrator
     volumes:
@@ -72,6 +76,7 @@ services:
       ORCH_URL: http://orchestrator-api:8002
       OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
       OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
+      JAEGER_ENDPOINT: http://jaeger:4317
     depends_on:
       - broker
       - orchestrator-api
@@ -86,6 +91,7 @@ services:
       METRICS_PORT: "9100"
       OTEL_EXPORTER_OTLP_ENDPOINT: https://otel-collector:4317
       OTEL_EXPORTER_OTLP_CERTIFICATE: /certs/ca.crt
+      JAEGER_ENDPOINT: http://jaeger:4317
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9100/health"]
       interval: 5s
@@ -102,6 +108,8 @@ services:
     build:
       context: .
       dockerfile: plugin_marketplace/Dockerfile
+    environment:
+      JAEGER_ENDPOINT: http://jaeger:4317
     volumes:
       - ./observability/certs:/certs:ro
     ports:
@@ -144,6 +152,14 @@ services:
       - prometheus
     ports:
       - "3000:3000"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.57
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    ports:
+      - "16686:16686"   # UI
+      - "4317:4317"     # OTLP gRPC
 
   rabbitmq:
     image: rabbitmq:3-management

--- a/docs/observability/jaeger.md
+++ b/docs/observability/jaeger.md
@@ -1,0 +1,12 @@
+# Jaeger Tracing
+
+The observability stack now includes a Jaeger instance for viewing distributed traces. The service is defined in `docker-compose.yml` and listens on `http://localhost:16686`.
+
+## Usage
+
+1. Run `observability/generate_certs.sh` once to create certificates.
+2. Start the stack with `docker-compose up`.
+3. Execute your workflows as normal. Spans from each service are exported to Jaeger.
+4. Open <http://localhost:16686> in your browser to explore traces.
+
+All services send metrics to the OpenTelemetry Collector and traces directly to Jaeger using the `JAEGER_ENDPOINT` environment variable.

--- a/observability/otel-collector.yaml
+++ b/observability/otel-collector.yaml
@@ -12,11 +12,18 @@ exporters:
     tls:
       cert_file: /certs/collector.crt
       key_file: /certs/collector.key
+  jaeger:
+    endpoint: jaeger:4317
+    tls:
+      insecure: true
 service:
   pipelines:
     metrics:
       receivers: [otlp]
       exporters: [prometheus]
+    traces:
+      receivers: [otlp]
+      exporters: [jaeger]
   telemetry:
     metrics:
       address: 0.0.0.0:8888

--- a/services/orchestrator_api.py
+++ b/services/orchestrator_api.py
@@ -17,7 +17,11 @@ from core.telemetry import setup_telemetry
 
 app = FastAPI()
 config = load_config()
-setup_telemetry(service_name="orchestrator_api", metrics_port=0)
+setup_telemetry(
+    service_name="orchestrator_api",
+    metrics_port=0,
+    jaeger_endpoint=config["tracing"]["jaeger_endpoint"],
+)
 FastAPIInstrumentor.instrument_app(app)
 
 _proc: Optional[subprocess.Popen] = None

--- a/services/plugin_marketplace/service.py
+++ b/services/plugin_marketplace/service.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import grpc
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import FileResponse
+from config import load_config
 
 try:
     from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
@@ -34,6 +35,7 @@ if setup_telemetry:
     _metrics_server, _ = setup_telemetry(
         service_name="plugin_marketplace",
         metrics_port=int(os.getenv("METRICS_PORT", "0")),
+        jaeger_endpoint=load_config()["tracing"]["jaeger_endpoint"],
     )
 if FastAPIInstrumentor:
     FastAPIInstrumentor.instrument_app(app)

--- a/worker/main.py
+++ b/worker/main.py
@@ -23,6 +23,7 @@ sentry_sdk.init(dsn=os.getenv("SENTRY_DSN"))
 setup_telemetry(
     service_name="worker",
     metrics_port=int(config["worker"]["metrics_port"]),
+    jaeger_endpoint=config["tracing"]["jaeger_endpoint"],
 )
 configure_logging()
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- deploy Jaeger in docker-compose
- export traces to Jaeger through the OpenTelemetry collector
- configure tracing settings in `core/config.py`
- send spans to Jaeger from all services
- document how to view traces in `docs/observability/jaeger.md`

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4c7e6598832ab43e53a5deb8d902