### PR TITLE
Add queue metrics and autoscaler

### DIFF
--- a/tests/integration/test_autoscaler.py
+++ b/tests/integration/test_autoscaler.py
@@ -1,0 +1,92 @@
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+import requests
+
+
+def start_broker(tmp_path: Path, port: int, metrics_port: int):
+    env = os.environ.copy()
+    env["DB_PATH"] = str(tmp_path / "api.db")
+    env["BROKER_METRICS_PORT"] = str(metrics_port)
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            "broker.main:app",
+            "--port",
+            str(port),
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        env=env,
+    )
+    base = f"http://localhost:{port}"
+    for _ in range(20):
+        try:
+            requests.get(f"{base}/tasks", timeout=1)
+            break
+        except requests.RequestException:
+            time.sleep(0.2)
+    return proc, env["DB_PATH"], base
+
+
+def run_autoscaler(base_url: str, metrics_port: int):
+    env = os.environ.copy()
+    env["BROKER_URL"] = base_url
+    env["BROKER_METRICS_PORT"] = str(metrics_port)
+    env["AUTOSCALER_LOOPS"] = "5"
+    env["AUTOSCALER_INTERVAL"] = "0.5"
+    env["WORKER_METRICS_PORT"] = "0"
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    result = subprocess.run(
+        [sys.executable, "-m", "worker.autoscaler"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def fetch_results(db_path: str) -> int:
+    conn = sqlite3.connect(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM task_results").fetchone()[0]
+    conn.close()
+    return count
+
+
+def queue_length(port: int) -> int:
+    resp = requests.get(f"http://localhost:{port}/metrics")
+    for line in resp.text.splitlines():
+        if line.startswith("broker_queue_length"):
+            return int(float(line.split()[-1]))
+    return 0
+
+
+@pytest.mark.integration
+def test_autoscaler_processes_queue(tmp_path):
+    metrics_port = 9300
+    broker_proc, db_path, base = start_broker(tmp_path, port=8010, metrics_port=metrics_port)
+    try:
+        for _ in range(2):
+            requests.post(
+                f"{base}/tasks",
+                json={"description": "demo", "command": "echo hi"},
+                timeout=5,
+            )
+        assert queue_length(metrics_port) == 2
+        run_autoscaler(base, metrics_port)
+        assert fetch_results(db_path) == 2
+        assert queue_length(metrics_port) == 0
+    finally:
+        broker_proc.terminate()
+        broker_proc.wait(timeout=5)
+

--- a/worker/autoscaler.py
+++ b/worker/autoscaler.py
@@ -1,0 +1,114 @@
+"""Simple auto-scaler for worker processes."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from urllib.parse import urlparse
+
+import requests
+
+from config import load_config
+
+
+class AutoScaler:
+    """Spawn or terminate workers based on broker queue length."""
+
+    def __init__(
+        self,
+        broker_url: str,
+        metrics_port: int,
+        max_workers: int = 4,
+        interval: float = 1.0,
+        loops: int | None = None,
+    ) -> None:
+        self.broker_url = broker_url.rstrip("/")
+        self.metrics_port = metrics_port
+        self.max_workers = max_workers
+        self.interval = interval
+        self.loops = loops
+        self.workers: list[subprocess.Popen] = []
+
+    # ------------------------------------------------------------------
+    def _metrics_url(self) -> str:
+        host = urlparse(self.broker_url).hostname or "localhost"
+        return f"http://{host}:{self.metrics_port}/metrics"
+
+    # ------------------------------------------------------------------
+    def _queue_length(self) -> int:
+        try:
+            resp = requests.get(self._metrics_url(), timeout=1)
+        except requests.RequestException:
+            return 0
+        for line in resp.text.splitlines():
+            if line.startswith("broker_queue_length"):
+                try:
+                    return int(float(line.split()[-1]))
+                except ValueError:
+                    return 0
+        return 0
+
+    # ------------------------------------------------------------------
+    def _spawn_worker(self) -> None:
+        env = os.environ.copy()
+        env.setdefault("BROKER_URL", self.broker_url)
+        env.setdefault("WORKER_METRICS_PORT", "0")
+        proc = subprocess.Popen(
+            [sys.executable, "-m", "worker.main"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            env=env,
+        )
+        self.workers.append(proc)
+
+    # ------------------------------------------------------------------
+    def _stop_worker(self) -> None:
+        proc = self.workers.pop()
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
+
+    # ------------------------------------------------------------------
+    def step(self) -> None:
+        desired = min(self.max_workers, self._queue_length())
+        while len(self.workers) < desired:
+            self._spawn_worker()
+        while len(self.workers) > desired:
+            self._stop_worker()
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        count = 0
+        while self.loops is None or count < self.loops:
+            self.step()
+            time.sleep(self.interval)
+            count += 1
+        while self.workers:
+            self._stop_worker()
+
+
+def main() -> None:
+    cfg = load_config()
+    broker_url = cfg["worker"]["broker_url"]
+    metrics_port = int(cfg["broker"]["metrics_port"])
+    max_workers = int(os.getenv("AUTOSCALER_MAX_WORKERS", "4"))
+    interval = float(os.getenv("AUTOSCALER_INTERVAL", "1"))
+    loops_env = os.getenv("AUTOSCALER_LOOPS")
+    loops = int(loops_env) if loops_env is not None else None
+    scaler = AutoScaler(
+        broker_url=broker_url,
+        metrics_port=metrics_port,
+        max_workers=max_workers,
+        interval=interval,
+        loops=loops,
+    )
+    scaler.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()
+


### PR DESCRIPTION
## Summary
- record broker queue length via Prometheus
- implement worker autoscaler based on metrics
- test autoscaler integration

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686e52e191d0832a8969c09a2ca1defc