### PR TITLE
Add plugin lifecycle commands and tests

### DIFF
--- a/plugins/cli.py
+++ b/plugins/cli.py
@@ -43,6 +43,17 @@ def _cmd_upload(args: argparse.Namespace) -> None:
     print("Plugin published to marketplace")
 
 
+def _cmd_update(args: argparse.Namespace) -> None:
+    pipeline.certify_and_publish(Path(args.plugin))
+    print("Plugin updated in marketplace")
+
+
+def _cmd_remove(args: argparse.Namespace) -> None:
+    from services.plugin_marketplace import service
+    service.remove_plugin(args.plugin_id)
+    print("Plugin removed from marketplace")
+
+
 def _cmd_review(args: argparse.Namespace) -> None:
     url = f"{args.url.rstrip('/')}/plugins/{args.plugin_id}/reviews"
     resp = requests.post(url, json={"rating": args.rating, "review": args.text})
@@ -72,6 +83,14 @@ def build_parser() -> argparse.ArgumentParser:
     upload_p = sub.add_parser("upload", help="Upload plugin to marketplace")
     upload_p.add_argument("plugin", help="Path to plugin directory")
     upload_p.set_defaults(func=_cmd_upload)
+
+    update_p = sub.add_parser("update", help="Update plugin in marketplace")
+    update_p.add_argument("plugin", help="Path to plugin directory")
+    update_p.set_defaults(func=_cmd_update)
+
+    remove_p = sub.add_parser("remove", help="Remove plugin from marketplace")
+    remove_p.add_argument("plugin_id", help="Plugin ID")
+    remove_p.set_defaults(func=_cmd_remove)
 
     review_p = sub.add_parser("review", help="Submit a review for a plugin")
     review_p.add_argument("plugin_id", help="Plugin ID")

--- a/services/plugin_marketplace/pipeline.py
+++ b/services/plugin_marketplace/pipeline.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from core.plugins import load_manifest
 from scripts.package_plugin import create_plugin_archive
 
-from .service import add_plugin, PLUGIN_DIR
+from .service import update_plugin, PLUGIN_DIR
 
 
 class ScanError(Exception):
@@ -34,7 +34,7 @@ def certify_and_publish(plugin_dir: Path) -> None:
     dest = Path(PLUGIN_DIR) / archive.name
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy(archive, dest)
-    add_plugin(
+    update_plugin(
         manifest.id,
         manifest.name,
         manifest.version,

--- a/tests/integration/test_plugin_lifecycle.py
+++ b/tests/integration/test_plugin_lifecycle.py
@@ -1,0 +1,71 @@
+import importlib
+import json
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from services.plugin_marketplace import service as svc
+from services.plugin_marketplace import pipeline
+
+
+def _start_service(tmp_path: Path):
+    import os
+    os.environ["PLUGIN_DB"] = str(tmp_path / "plugins.db")
+    os.environ["PLUGIN_DIR"] = str(tmp_path / "repo")
+    os.environ["GRPC_PORT"] = "60061"
+    module = importlib.reload(svc)
+    module.init_db()
+    return module
+
+
+def _stop_service(module):
+    if module._grpc_server:
+        module._grpc_server.stop(None)
+        time.sleep(0.2)
+
+
+def _make_plugin(tmp_path: Path, plugin_id: str, version: str) -> Path:
+    plugin_dir = tmp_path / f"{plugin_id}_{version}"
+    plugin_dir.mkdir()
+    manifest = {
+        "id": plugin_id,
+        "name": plugin_id.title(),
+        "version": version,
+        "permissions": ["read_files"],
+        "dependencies": [],
+        "compatibility": ">=0.1",
+    }
+    (plugin_dir / "manifest.json").write_text(json.dumps(manifest))
+    (plugin_dir / "plugin.py").write_text("def run():\n    return 'ok'\n")
+    return plugin_dir
+
+
+@pytest.fixture()
+def marketplace(tmp_path):
+    module = _start_service(tmp_path)
+    yield module
+    _stop_service(module)
+
+
+def test_update_and_remove_plugin(marketplace, tmp_path):
+    first = _make_plugin(tmp_path, "demo", "0.1.0")
+    pipeline.certify_and_publish(first)
+
+    client = TestClient(marketplace.app)
+    resp = client.get("/plugins")
+    assert any(p["version"] == "0.1.0" for p in resp.json() if p["id"] == "demo")
+
+    updated = _make_plugin(tmp_path, "demo", "0.2.0")
+    pipeline.certify_and_publish(updated)
+
+    resp = client.get("/plugins")
+    assert any(p["version"] == "0.2.0" for p in resp.json() if p["id"] == "demo")
+    files = list((tmp_path / "repo").iterdir())
+    assert len(files) == 1 and "0.2.0" in files[0].name
+
+    svc.remove_plugin("demo")
+    resp = client.get("/plugins")
+    assert all(p["id"] != "demo" for p in resp.json())
+    assert not any((tmp_path / "repo").iterdir())


### PR DESCRIPTION
## Summary
- add `update` and `remove` subcommands to plugin CLI
- support updating and deleting plugins in marketplace service
- ensure packaging pipeline uses `update_plugin`
- test plugin lifecycle through publish, update and remove

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionError when running autoscaler integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_686e62174734832a9f2cff9002bbd08a