### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "AI-SWA DevContainer",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "postCreateCommand": "pip install -r requirements.txt",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-azuretools.vscode-docker"
+      ],
+      "tasks": {
+        "version": "2.0.0",
+        "tasks": [
+          {
+            "label": "Run Tests",
+            "type": "shell",
+            "command": "pytest --maxfail=1 --disable-warnings -q",
+            "group": "test",
+            "presentation": {
+              "reveal": "always"
+            },
+            "problemMatcher": "$pytest"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/docs/deployment/devcontainer.md
+++ b/docs/deployment/devcontainer.md
@@ -1,0 +1,20 @@
+# Using the VS Code Dev Container
+
+The repository ships a ready to use [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) definition.
+It provides a consistent environment with Python 3.12 and the required extensions installed.
+
+## Quick start
+
+1. Install the **Dev Containers** extension for VS Code.
+2. Open this folder in VS Code and choose **Reopen in Container** when prompted.
+3. The image `mcr.microsoft.com/devcontainers/python:3.12` will be pulled and dependencies installed using `pip install -r requirements.txt`.
+
+## Running tests
+
+A `Run Tests` task is included in the container. Trigger it from the command palette (`Run Task`) or execute:
+
+```bash
+pytest --maxfail=1 --disable-warnings -q
+```
+
+This runs the suite inside the container using the same configuration as CI.


### PR DESCRIPTION
## Summary
- provide a default VS Code devcontainer using Python 3.12
- include a Run Tests task inside the devcontainer
- document how to use the container

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: google.protobuf.runtime_version.VersionError)*

------
https://chatgpt.com/codex/tasks/task_e_686e70d01c10832a9190dc7abccf075d