### PR TITLE
Add Trivy scan and harden Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,13 @@ EOF
         with:
           name: bandit-report
           path: bandit.json
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@v0.22.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: HIGH,CRITICAL
+          exit-code: 1
       - name: Build plugin sandbox image
         run: docker build -t plugin-test-sandbox -f plugins/sandbox/Dockerfile .
       - name: Run plugin tests in sandbox

--- a/api_gateway/Dockerfile
+++ b/api_gateway/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && useradd --create-home appuser
 COPY services/api_gateway.py ./services/api_gateway.py
 EXPOSE 8080
+USER appuser
 ENTRYPOINT ["uvicorn", "services.api_gateway:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/broker/Dockerfile
+++ b/broker/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && useradd --create-home appuser
 COPY broker ./broker
 COPY config.yaml ./
 EXPOSE 8000
+USER appuser
 ENTRYPOINT ["uvicorn", "broker.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && useradd --create-home appuser
 COPY core ./core
 COPY config.yaml ./
 COPY tasks.yml ./
+USER appuser
 ENTRYPOINT ["python", "-m", "core.cli", "run", "--memory", "state.json"]

--- a/docs/deployment/container_hardening.md
+++ b/docs/deployment/container_hardening.md
@@ -1,0 +1,24 @@
+# Container Hardening
+
+This project ships multiple service images. Follow these guidelines to keep containers secure in production.
+
+## Least privilege
+
+- Each Dockerfile creates an unprivileged user and switches to it. Avoid running processes as root.
+- Limit container capabilities with `--cap-drop=ALL` and only add the ones required by the service.
+
+## Minimal base images
+
+- Use slim or alpine variants of base images to reduce the attack surface.
+- Regularly update images and rebuild to pull in security patches.
+
+## Vulnerability scanning
+
+- The CI pipeline runs `pip-audit`, `npm audit`, and **Trivy** to detect known vulnerabilities.
+- Review scan reports on every pull request and fix high or critical issues before release.
+
+## Runtime security
+
+- Mount volumes read-only where possible.
+- Configure resource limits to prevent denial-of-service attacks.
+- Keep secrets out of images by passing them via environment variables or secret stores.

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && useradd --create-home appuser
 COPY core ./core
 COPY config.yaml ./
 COPY tasks.yml ./
+USER appuser
 ENTRYPOINT ["python", "-m", "core.cli", "run", "--memory", "state.json"]

--- a/orchestrator_api/Dockerfile
+++ b/orchestrator_api/Dockerfile
@@ -1,10 +1,12 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && useradd --create-home appuser
 COPY services/orchestrator_api.py ./services/orchestrator_api.py
 COPY core ./core
 COPY ai_swa ./ai_swa
 COPY config.yaml ./
 EXPOSE 8002
+USER appuser
 ENTRYPOINT ["uvicorn", "services.orchestrator_api:app", "--host", "0.0.0.0", "--port", "8002"]

--- a/plugin_marketplace/Dockerfile
+++ b/plugin_marketplace/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && useradd --create-home appuser
 COPY services/plugin_marketplace ./services/plugin_marketplace
 COPY core ./core
 EXPOSE 8003
+USER appuser
 ENTRYPOINT ["uvicorn", "services.plugin_marketplace.service:app", "--host", "0.0.0.0", "--port", "8003"]

--- a/services/node/Dockerfile
+++ b/services/node/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:18-alpine
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --omit=dev
+RUN npm install --omit=dev && addgroup -S app && adduser -S app -G app
 COPY io_server.js ./
 EXPOSE 50051
+USER app
 CMD ["node", "io_server.js"]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt \
+    && useradd --create-home appuser
 COPY worker/main.py ./
 COPY config.yaml ./
+USER appuser
 ENTRYPOINT ["python", "main.py"]


### PR DESCRIPTION
## Summary
- run Docker containers as non-root users
- scan repository with Trivy during CI
- document container hardening guidelines

## Testing
- `pytest tests/test_archive_tasks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_686e7979bb84832a9313a43290706eff