### PR TITLE
Add Terraform modules for deployment

### DIFF
--- a/deploy/terraform/envs/production.tfvars
+++ b/deploy/terraform/envs/production.tfvars
@@ -1,0 +1,9 @@
+namespace                     = "ai-swa-prod"
+orchestrator_image_tag        = "stable"
+worker_image_tag              = "stable"
+broker_image_tag              = "stable"
+plugin_marketplace_image_tag  = "stable"
+orchestrator_replicas         = 3
+worker_replicas               = 3
+broker_replicas               = 2
+plugin_marketplace_replicas   = 2

--- a/deploy/terraform/envs/staging.tfvars
+++ b/deploy/terraform/envs/staging.tfvars
@@ -1,0 +1,9 @@
+namespace                     = "ai-swa-staging"
+orchestrator_image_tag        = "latest"
+worker_image_tag              = "latest"
+broker_image_tag              = "latest"
+plugin_marketplace_image_tag  = "latest"
+orchestrator_replicas         = 1
+worker_replicas               = 1
+broker_replicas               = 1
+plugin_marketplace_replicas   = 1

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9.0"
+    }
+  }
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig
+  }
+}
+
+module "orchestrator" {
+  source         = "./modules/orchestrator"
+  namespace      = var.namespace
+  image_tag      = var.orchestrator_image_tag
+  replica_count  = var.orchestrator_replicas
+}
+
+module "worker" {
+  source         = "./modules/worker"
+  namespace      = var.namespace
+  image_tag      = var.worker_image_tag
+  replica_count  = var.worker_replicas
+}
+
+module "broker" {
+  source         = "./modules/broker"
+  namespace      = var.namespace
+  image_tag      = var.broker_image_tag
+  replica_count  = var.broker_replicas
+}
+
+module "plugin_marketplace" {
+  source         = "./modules/plugin-marketplace"
+  namespace      = var.namespace
+  image_tag      = var.plugin_marketplace_image_tag
+  replica_count  = var.plugin_marketplace_replicas
+}

--- a/deploy/terraform/modules/broker/main.tf
+++ b/deploy/terraform/modules/broker/main.tf
@@ -1,0 +1,15 @@
+resource "helm_release" "broker" {
+  name       = "broker"
+  chart      = "${path.module}/../../../helm/broker"
+  namespace  = var.namespace
+
+  set {
+    name  = "image.tag"
+    value = var.image_tag
+  }
+
+  set {
+    name  = "replicaCount"
+    value = var.replica_count
+  }
+}

--- a/deploy/terraform/modules/broker/outputs.tf
+++ b/deploy/terraform/modules/broker/outputs.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = helm_release.broker.name
+}

--- a/deploy/terraform/modules/broker/variables.tf
+++ b/deploy/terraform/modules/broker/variables.tf
@@ -1,0 +1,13 @@
+variable "namespace" {
+  type = string
+}
+
+variable "image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "replica_count" {
+  type    = number
+  default = 1
+}

--- a/deploy/terraform/modules/orchestrator/main.tf
+++ b/deploy/terraform/modules/orchestrator/main.tf
@@ -1,0 +1,15 @@
+resource "helm_release" "orchestrator" {
+  name       = "orchestrator"
+  chart      = "${path.module}/../../../helm/orchestrator"
+  namespace  = var.namespace
+
+  set {
+    name  = "image.tag"
+    value = var.image_tag
+  }
+
+  set {
+    name  = "replicaCount"
+    value = var.replica_count
+  }
+}

--- a/deploy/terraform/modules/orchestrator/outputs.tf
+++ b/deploy/terraform/modules/orchestrator/outputs.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = helm_release.orchestrator.name
+}

--- a/deploy/terraform/modules/orchestrator/variables.tf
+++ b/deploy/terraform/modules/orchestrator/variables.tf
@@ -1,0 +1,13 @@
+variable "namespace" {
+  type = string
+}
+
+variable "image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "replica_count" {
+  type    = number
+  default = 1
+}

--- a/deploy/terraform/modules/plugin-marketplace/main.tf
+++ b/deploy/terraform/modules/plugin-marketplace/main.tf
@@ -1,0 +1,15 @@
+resource "helm_release" "plugin_marketplace" {
+  name       = "plugin-marketplace"
+  chart      = "${path.module}/../../../helm/plugin-marketplace"
+  namespace  = var.namespace
+
+  set {
+    name  = "image.tag"
+    value = var.image_tag
+  }
+
+  set {
+    name  = "replicaCount"
+    value = var.replica_count
+  }
+}

--- a/deploy/terraform/modules/plugin-marketplace/outputs.tf
+++ b/deploy/terraform/modules/plugin-marketplace/outputs.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = helm_release.plugin_marketplace.name
+}

--- a/deploy/terraform/modules/plugin-marketplace/variables.tf
+++ b/deploy/terraform/modules/plugin-marketplace/variables.tf
@@ -1,0 +1,13 @@
+variable "namespace" {
+  type = string
+}
+
+variable "image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "replica_count" {
+  type    = number
+  default = 1
+}

--- a/deploy/terraform/modules/worker/main.tf
+++ b/deploy/terraform/modules/worker/main.tf
@@ -1,0 +1,15 @@
+resource "helm_release" "worker" {
+  name       = "worker"
+  chart      = "${path.module}/../../../helm/worker"
+  namespace  = var.namespace
+
+  set {
+    name  = "image.tag"
+    value = var.image_tag
+  }
+
+  set {
+    name  = "replicaCount"
+    value = var.replica_count
+  }
+}

--- a/deploy/terraform/modules/worker/outputs.tf
+++ b/deploy/terraform/modules/worker/outputs.tf
@@ -1,0 +1,3 @@
+output "name" {
+  value = helm_release.worker.name
+}

--- a/deploy/terraform/modules/worker/variables.tf
+++ b/deploy/terraform/modules/worker/variables.tf
@@ -1,0 +1,13 @@
+variable "namespace" {
+  type = string
+}
+
+variable "image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "replica_count" {
+  type    = number
+  default = 1
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -1,0 +1,51 @@
+variable "kubeconfig" {
+  description = "Path to kubeconfig file"
+  type        = string
+  default     = "~/.kube/config"
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace to deploy into"
+  type        = string
+  default     = "ai-swa"
+}
+
+variable "orchestrator_image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "worker_image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "broker_image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "plugin_marketplace_image_tag" {
+  type    = string
+  default = "latest"
+}
+
+variable "orchestrator_replicas" {
+  type    = number
+  default = 1
+}
+
+variable "worker_replicas" {
+  type    = number
+  default = 1
+}
+
+variable "broker_replicas" {
+  type    = number
+  default = 1
+}
+
+variable "plugin_marketplace_replicas" {
+  type    = number
+  default = 1
+}

--- a/docs/deployment/terraform.md
+++ b/docs/deployment/terraform.md
@@ -1,0 +1,32 @@
+# Deploying AI-SWA with Terraform
+
+This repository includes Terraform modules for installing the core services on a Kubernetes cluster via Helm. Modules live under `deploy/terraform/modules` and cover the following components:
+
+- **orchestrator** – coordinates task execution
+- **worker** – executes shell commands
+- **broker** – REST API storing tasks and results
+- **plugin marketplace** – serves plugins over HTTP and gRPC
+
+## Setup
+
+1. Install Terraform and ensure access to a Kubernetes cluster.
+2. Configure the Helm provider by setting the `kubeconfig` variable if your config is not in `~/.kube/config`.
+3. Choose a variables file for your environment:
+   - `envs/staging.tfvars` – single replica deployment using `latest` images.
+   - `envs/production.tfvars` – scaled deployment using `stable` tags.
+4. Initialize the working directory:
+
+```bash
+cd deploy/terraform
+terraform init
+```
+
+5. Review the plan and apply:
+
+```bash
+terraform plan -var-file=envs/staging.tfvars
+terraform apply -var-file=envs/staging.tfvars
+```
+
+Swap in `envs/production.tfvars` for a production deployment. The modules will install the Helm charts defined under `deploy/helm/`.
+


### PR DESCRIPTION
## Summary
- create Terraform modules for orchestrator, worker, broker and plugin marketplace
- provide variable files for staging and production
- document Terraform deployment steps

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_686e7ebe31d0832ab5c20db948d9b3cd