### PR TITLE
Refactor executor tests

### DIFF
--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,49 +1,36 @@
 import os
 from pathlib import Path
 import tempfile
+import pytest
 
-def test_execute_task_with_description(executor, task_factory):
-    """Logger should include the task description."""
-    task = task_factory(id="t1", description="Task One Description")
+
+@pytest.mark.parametrize(
+    "task_kwargs, remove_desc, remove_id, expected",
+    [
+        ({"id": "t1", "description": "Task One Description"}, False, False,
+         ("Executing task: %s", "Task One Description")),
+        ({"id": "d1", "description": "Dict Task Description"}, False, False,
+         ("Executing task: %s", "Dict Task Description")),
+        ({"id": "t_other", "description": "Other attributes test", "priority": 10}, False, False,
+         ("Executing task: %s", "Other attributes test")),
+        ({"id": "t2"}, True, False,
+         ("Executing task ID: %s (No description found)", "t2")),
+        ({"id": "d2"}, True, False,
+         ("Executing task ID: %s (No description found)", "d2")),
+        ({"id": 0}, True, True,
+         ("Executing task: (No description or ID found)",)),
+    ],
+)
+def test_execute_task_logging(executor, task_factory, task_kwargs, remove_desc, remove_id, expected):
+    """Executor logs correct messages for various task definitions."""
+    task = task_factory(**task_kwargs)
+    if remove_desc:
+        delattr(task, "description")
+    if remove_id:
+        delattr(task, "id")
+
     executor.execute(task)
-    executor.logger.info.assert_called_once_with("Executing task: %s", "Task One Description")
-
-
-def test_execute_task_with_id_no_description(executor, task_factory):
-    """Fallback to task id when description is missing."""
-    task = task_factory(id="t2")
-    delattr(task, "description")
-    executor.execute(task)
-    executor.logger.info.assert_called_once_with("Executing task ID: %s (No description found)", "t2")
-
-
-def test_execute_task_no_description_no_id(executor, task_factory):
-    """Handle tasks lacking both description and id."""
-    task = task_factory(id=0)
-    delattr(task, "description")
-    delattr(task, "id")
-    executor.execute(task)
-    executor.logger.info.assert_called_once_with("Executing task: (No description or ID found)")
-
-
-def test_execute_task_as_dict_with_description(executor, task_factory):
-    """Task dataclass mimics attribute access for mapping inputs."""
-    task = task_factory(id="d1", description="Dict Task Description")
-    executor.execute(task)
-    executor.logger.info.assert_called_once_with("Executing task: %s", "Dict Task Description")
-
-
-def test_execute_task_as_dict_with_id_no_description(executor, task_factory):
-    task = task_factory(id="d2")
-    delattr(task, "description")
-    executor.execute(task)
-    executor.logger.info.assert_called_once_with("Executing task ID: %s (No description found)", "d2")
-
-
-def test_execute_task_object_with_other_attributes(executor, task_factory):
-    task = task_factory(id="t_other", description="Other attributes test", priority=10)
-    executor.execute(task)
-    executor.logger.info.assert_called_once_with("Executing task: %s", "Other attributes test")
+    executor.logger.info.assert_called_once_with(*expected)
 
 
 def test_execute_task_with_command_creates_log(executor, task_factory):


### PR DESCRIPTION
## Summary
- parametrize executor logging tests to reduce cyclomatic complexity

## Testing
- `pytest tests/test_executor.py -q`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionRefusedError in autoscaler integration test)*

------
https://chatgpt.com/codex/tasks/task_e_686e8f3e851c832aacb84f4227f8702b