### PR TITLE
Refactor planner budget logic

### DIFF
--- a/core/planner.py
+++ b/core/planner.py
@@ -1,3 +1,10 @@
+"""Core planning algorithm used by the orchestrator.
+
+The heavy lifting such as dependency evaluation and budget tracking is
+implemented in :mod:`core.planner_utils` to keep this module small and
+easy to maintain.
+"""
+
 from typing import List, Optional
 import logging
 
@@ -10,6 +17,7 @@ from .planner_utils import (
     filter_ready_tasks,
     is_budget_exhausted,
     should_warn_about_budget,
+    increment_cost_and_warn,
 )
 
 logger = logging.getLogger(__name__)
@@ -54,17 +62,11 @@ class Planner:
             return None
 
         selected = select_highest_priority(ready_tasks)
-        self.cost_used += 1
-        if should_warn_about_budget(
-            self.budget,
+        self.cost_used, self._warned = increment_cost_and_warn(
             self.cost_used,
+            self.budget,
             self.warning_threshold,
             self._warned,
-        ):
-            logger.warning(
-                "Planner budget at %d%%",
-                int(100 * self.cost_used / self.budget),
-            )
-            self._warned = True
+        )
         return selected
 

--- a/core/planner_utils.py
+++ b/core/planner_utils.py
@@ -1,3 +1,10 @@
+"""Utility helpers for :mod:`core.planner`.
+
+These helpers encapsulate individual pieces of logic used by
+``Planner`` to keep the main algorithm concise.  They cover
+dependency resolution, priority selection and budget tracking.
+"""
+
 import logging
 from typing import List, Optional
 
@@ -68,3 +75,21 @@ def should_warn_about_budget(budget: Optional[int], cost_used: int, warning_thre
         and cost_used >= budget * warning_threshold
         and cost_used < budget
     )
+
+
+def increment_cost_and_warn(
+    cost_used: int,
+    budget: Optional[int],
+    warning_threshold: float,
+    warned: bool,
+) -> tuple[int, bool]:
+    """Increment ``cost_used`` and emit a warning if nearing ``budget``."""
+
+    cost_used += 1
+    if should_warn_about_budget(budget, cost_used, warning_threshold, warned):
+        logger.warning(
+            "Planner budget at %d%%",
+            int(100 * cost_used / budget),
+        )
+        warned = True
+    return cost_used, warned

--- a/tasks.yml
+++ b/tasks.yml
@@ -101,7 +101,7 @@
   description: Refactor core/planner.py complexity 41
   dependencies: []
   priority: 3
-  status: pending
+  status: done
   area: core
   actionable_steps: []
   acceptance_criteria: []


### PR DESCRIPTION
## Summary
- split budget handling into `increment_cost_and_warn`
- explain planner design in docs and code comments
- mark complexity refactor task as done

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_686ea4023c08832a9063c56850cfd0b9