### PR TITLE
Add WSJF/RL prioritization notes

### DIFF
--- a/research/RB-003_Vision_Engine_Prioritization.md
+++ b/research/RB-003_Vision_Engine_Prioritization.md
@@ -3,16 +3,16 @@
 This outline surveys how modern software projects prioritize work and how those ideas could shape the Vision Engine.
 
 ## Literature Summary
-- **WSJF (Weighted Shortest Job First)** from the Scaled Agile Framework ranks work by dividing business value by job size.
-- **Reinforcement learning for scheduling** (e.g., Jaderberg 2017) explores agents that adapt priorities based on observed reward.
-- **Multi-criteria decision analysis** methods like AHP compare qualitative factors when quantitative data is sparse.
+- **WSJF (Weighted Shortest Job First)** from the Scaled Agile Framework scores each job as `(business value + time criticality + risk reduction) / job size` to maximize value delivered per unit of effort.
+- **Reinforcement learning for backlog ordering** (e.g., Jaderberg 2017, Mohr 2021) trains agents that refine priorities based on observed reward signals such as delivery lead time or customer impact.
+- **Multi-criteria decision analysis** methods like AHP and MoSCoW compare qualitative factors when quantitative data is sparse.
 
 ## Open Questions
-- How can WSJF heuristics seed an RL agent without locking in bias?
-- What metrics best capture long-term architectural value versus short-term velocity?
-- Can feedback from the Reflector Core autonomously refine prioritization weights?
+- How can WSJF heuristics seed an RL agent without locking in bias toward short-term metrics?
+- What reward signals best capture long-term architectural value versus rapid feature delivery?
+- Can feedback from the Reflector Core autonomously adjust exploration versus exploitation when prioritizing tasks?
 
 ## Implementation Acceptance Criteria
-- Future prioritization tasks should implement a baseline WSJF algorithm.
-- RL models must ingest Reflector metrics to adjust ranking dynamically.
-- Tests should demonstrate improved backlog ordering against historical baselines.
+- Provide a baseline WSJF algorithm within the prioritization module.
+- Ingest Reflector metrics into an RL model that adapts task ranking over time.
+- Demonstrate backlog improvements against historical baselines using tests or simulation.

--- a/tasks.yml
+++ b/tasks.yml
@@ -112,7 +112,7 @@
   dependencies:
   - 53
   priority: 3
-  status: pending
+  status: done
   area: research
   actionable_steps:
   - Summarize literature on WSJF and RL-based prioritization


### PR DESCRIPTION
## Summary
- refine research on prioritization techniques
- mark research task complete

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_686ea7c049d0832aa05a485b5f5eab22