### PR TITLE
Implement QA, Docs, and Supervisor agents

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -7,3 +7,9 @@ except Exception:  # pragma: no cover - optional grpc dependency
         """Fallback when ``grpc`` is unavailable."""
         raise ImportError("grpc is required for io_ping")
 
+from .qa_agent import QAAgent
+from .docs_agent import DocsAgent
+from .supervisor import Supervisor
+
+__all__ = ["io_ping", "QAAgent", "DocsAgent", "Supervisor"]
+

--- a/core/docs_agent.py
+++ b/core/docs_agent.py
@@ -1,0 +1,32 @@
+"""SWA-DOCS-01: Documentation verification agent."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+
+class DocsAgent:
+    """Verify code comments and docstring completeness."""
+
+    def __init__(self, targets: list[str] | None = None, report_dir: Path | str = "docs/reports") -> None:
+        self.targets = targets or ["core"]
+        self.report_dir = Path(report_dir)
+        self.report_dir.mkdir(parents=True, exist_ok=True)
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    def run_pylint_docstrings(self) -> Path:
+        """Run pylint docstring checks and return log path."""
+        report = self.report_dir / "docstring.log"
+        cmd = ["pylint", "--disable=all", "--enable=missing-docstring", *self.targets]
+        with report.open("w") as fh:
+            subprocess.run(cmd, stdout=fh, stderr=subprocess.STDOUT, check=False)
+        return report
+
+    # ------------------------------------------------------------------
+    def run(self) -> list[Path]:
+        """Execute documentation checks."""
+        self.logger.info("DocsAgent validating comments and docstrings")
+        return [self.run_pylint_docstrings()]

--- a/core/qa_agent.py
+++ b/core/qa_agent.py
@@ -1,0 +1,40 @@
+"""SWA-QA-01: Static analysis and security scanning agent."""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+
+
+class QAAgent:
+    """Run static analysis tools like Bandit and Pylint."""
+
+    def __init__(self, targets: list[str] | None = None, report_dir: Path | str = "docs/reports") -> None:
+        self.targets = targets or ["core"]
+        self.report_dir = Path(report_dir)
+        self.report_dir.mkdir(parents=True, exist_ok=True)
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    def run_bandit(self) -> Path:
+        """Execute Bandit against ``self.targets`` and return report path."""
+        report = self.report_dir / "bandit.json"
+        cmd = ["bandit", "-r", *self.targets, "-x", "tests", "-f", "json", "-o", str(report)]
+        subprocess.run(cmd, check=False)
+        return report
+
+    # ------------------------------------------------------------------
+    def run_pylint(self) -> Path:
+        """Run pylint on ``self.targets`` and return log file path."""
+        report = self.report_dir / "pylint.log"
+        with report.open("w") as fh:
+            subprocess.run(["pylint", *self.targets], stdout=fh, stderr=subprocess.STDOUT, check=False)
+        return report
+
+    # ------------------------------------------------------------------
+    def run(self) -> list[Path]:
+        """Run all QA checks and return list of generated reports."""
+        self.logger.info("QAAgent running static analysis")
+        reports = [self.run_bandit(), self.run_pylint()]
+        return reports

--- a/core/supervisor.py
+++ b/core/supervisor.py
@@ -1,0 +1,47 @@
+"""SWA-SUPER-01: Simple supervisor dispatching specialized agents."""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+
+from .qa_agent import QAAgent
+from .docs_agent import DocsAgent
+
+
+class Supervisor:
+    """Activate QA or Docs agents based on commit labels."""
+
+    def __init__(self, qa_agent: QAAgent | None = None, docs_agent: DocsAgent | None = None) -> None:
+        self.qa_agent = qa_agent or QAAgent()
+        self.docs_agent = docs_agent or DocsAgent()
+        self.logger = logging.getLogger(__name__)
+
+    # ------------------------------------------------------------------
+    def _last_commit_message(self) -> str:
+        result = subprocess.run([
+            "git",
+            "log",
+            "-1",
+            "--pretty=%B",
+        ], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True, check=False)
+        return result.stdout.strip()
+
+    # ------------------------------------------------------------------
+    def _parse_label(self, message: str) -> str:
+        match = re.match(r"(\w+)\(", message)
+        return match.group(1) if match else ""
+
+    # ------------------------------------------------------------------
+    def run(self, commit_message: str | None = None) -> None:
+        """Run agents based on ``commit_message`` or last git commit."""
+        message = commit_message or self._last_commit_message()
+        label = self._parse_label(message)
+        self.logger.info("Supervisor handling label: %s", label)
+        if label == "bug":
+            self.logger.info("Triggering QAAgent")
+            self.qa_agent.run()
+        if label == "docs":
+            self.logger.info("Triggering DocsAgent")
+            self.docs_agent.run()

--- a/tasks.yml
+++ b/tasks.yml
@@ -1980,7 +1980,7 @@
     - A commit with a 'bug' label triggers the SWA-QA-01 agent.
     - A commit with a 'docs' label triggers the SWA-DOCS-01 agent.
   priority: 2
-  status: pending
+  status: done
 - id: 208
   task_id: DOC-001
   title: "Establish Documentation-as-a-Product Framework"
@@ -2126,7 +2126,7 @@
   description: Implement SWA-QA-01 and SWA-DOCS-01 agents so that commits with 'bug' or 'docs' labels trigger automated QA and documentation checks.
   dependencies: []
   priority: 2
-  status: pending
+  status: done
   area: core
   actionable_steps:
     - Develop the QA agent with Bandit integration and static analysis tooling.

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,53 @@
+from core.qa_agent import QAAgent
+from core.docs_agent import DocsAgent
+from core.supervisor import Supervisor
+
+
+class DummyQA(QAAgent):
+    def __init__(self):
+        self.called = False
+
+    def run(self):
+        self.called = True
+        return []
+
+
+class DummyDocs(DocsAgent):
+    def __init__(self):
+        self.called = False
+
+    def run(self):
+        self.called = True
+        return []
+
+
+def test_qa_agent_generates_reports(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text("import os\n")
+    agent = QAAgent(targets=[str(tmp_path)], report_dir=tmp_path)
+    reports = agent.run()
+    assert (tmp_path / "bandit.json").exists()
+    assert (tmp_path / "pylint.log").exists()
+    assert reports
+
+
+def test_docs_agent_generates_report(tmp_path):
+    sample = tmp_path / "sample.py"
+    sample.write_text("def foo():\n    pass\n")
+    agent = DocsAgent(targets=[str(tmp_path)], report_dir=tmp_path)
+    reports = agent.run()
+    assert (tmp_path / "docstring.log").exists()
+    assert reports
+
+
+def test_supervisor_dispatch():
+    qa = DummyQA()
+    docs = DummyDocs()
+    sup = Supervisor(qa_agent=qa, docs_agent=docs)
+    sup.run(commit_message="bug(core): fix issue")
+    assert qa.called and not docs.called
+
+    qa.called = False
+    docs.called = False
+    sup.run(commit_message="docs(core): update")
+    assert docs.called and not qa.called


### PR DESCRIPTION
## Summary
- implement `QAAgent` running Bandit and pylint
- implement `DocsAgent` checking for missing docstrings
- add `Supervisor` to launch these agents based on commit labels
- expose new agents in `core.__init__`
- mark tasks 207 and 218 as done
- add tests for new agents and supervisor

## Testing
- `pip install -q -r requirements.lock`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: HTTPConnectionPool(host='localhost', port=8010) - Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_686ea969272c832a81839a60a7f7e79b