### PR TITLE
Fix self auditor class handling and CLI

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -16,6 +16,7 @@ from .reflector import Reflector
 from .self_auditor import SelfAuditor
 from .telemetry import setup_telemetry
 from .log_utils import configure_logging
+from .config import load_config
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 

--- a/core/self_auditor.py
+++ b/core/self_auditor.py
@@ -88,13 +88,21 @@ class SelfAuditor:
         for item in complexity_results:
             complexity = item.complexity
             rank = cc_rank(complexity)
+
+            if hasattr(item, "methods"):
+                node_type = "class"
+            elif getattr(item, "classname", None):
+                node_type = "method"
+            else:
+                node_type = "function"
+
             complexity_data.append(
                 {
                     "name": item.name,
                     "complexity": complexity,
                     "rank": rank,
                     "lineno": item.lineno,
-                    "type": item.classname or "function",
+                    "type": node_type,
                 }
             )
             max_complexity = max(max_complexity, complexity)

--- a/tests/test_self_auditor.py
+++ b/tests/test_self_auditor.py
@@ -64,3 +64,17 @@ def test_self_auditor_wily_history(tmp_path):
     meta = tasks[0]["metadata"]
     assert "delta_complexity" in meta
     assert meta["delta_complexity"] != 0
+
+
+def test_self_auditor_class_nodes(tmp_path):
+    pyfile = tmp_path / "cls.py"
+    pyfile.write_text(
+        "class Foo:\n    def bar(self):\n        if True:\n            return 1\n        return 0\n"
+    )
+    auditor = SelfAuditor(complexity_threshold=1)
+    metrics = auditor.analyze([pyfile])
+    key = str(pyfile)
+    assert key in metrics
+    data = metrics[key]
+    types = {item["type"] for item in data["complexity"]}
+    assert "class" in types


### PR DESCRIPTION
## Summary
- fix orchestrator CLI import of load_config
- handle radon Class nodes in SelfAuditor
- test SelfAuditor with class definitions

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686efa522e20832ab3f261820ff438ca