### PR TITLE
Implement state vector builder

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -251,7 +251,7 @@
   description: Build state representation vector using observability data
   dependencies: []
   priority: 2
-  status: pending
+  status: done
   area: reflector
   actionable_steps: []
   acceptance_criteria: []

--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -20,6 +20,14 @@ def test_state_builder_numeric_filter(tmp_path):
     assert state == {"coverage": 95.0}
 
 
+def test_state_builder_vector(tmp_path):
+    metrics_file = tmp_path / "m.json"
+    metrics_file.write_text('{"b": 2, "a": 1}')
+    provider = MetricsProvider(metrics_file)
+    builder = StateBuilder(provider)
+    assert builder.vector() == [1.0, 2.0]
+
+
 def test_ppo_agent_training_step(tmp_path):
     metrics_file = tmp_path / "m.json"
     metrics_file.write_text('{"reward": 1}')

--- a/vision/ppo/state_builder.py
+++ b/vision/ppo/state_builder.py
@@ -13,8 +13,14 @@ class StateBuilder:
 
     def build(self) -> Dict[str, float]:
         metrics = self.metrics_provider.collect()
+
         return {
             k: float(v)
             for k, v in metrics.items()
             if isinstance(v, (int, float))
         }
+
+    def vector(self) -> list[float]:
+        """Return a sorted list of numeric metric values."""
+        state = self.build()
+        return [state[k] for k in sorted(state.keys())]


### PR DESCRIPTION
## Summary
- extend `StateBuilder` with a `vector` method to generate ordered feature vectors
- test new functionality in `test_state_builder_vector`
- mark task 63 as done

## Testing
- `pytest tests/test_ppo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686f3ae68e14832aa90ad9375b4ae622