### PR TITLE
Implement generative code LLM wrapper

### DIFF
--- a/core/code_llm.py
+++ b/core/code_llm.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+"""Utilities for generating code actions via a fine-tuned LLM."""
+
+from dataclasses import dataclass
+from typing import List, Optional, Any
+
+
+@dataclass
+class CodeLLM:
+    """Wrapper around a text-generation pipeline for code actions."""
+
+    model_name: str = "distilgpt2"
+    pipeline: Optional[Any] = None
+
+    def __post_init__(self) -> None:
+        if self.pipeline is None:
+            from transformers import (
+                AutoModelForCausalLM,
+                AutoTokenizer,
+                pipeline as hf_pipeline,
+            )
+
+            tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+            model = AutoModelForCausalLM.from_pretrained(self.model_name)
+            self.pipeline = hf_pipeline(
+                "text-generation", model=model, tokenizer=tokenizer
+            )
+
+    def generate_actions(
+        self, prompt: str, max_tokens: int = 64, num_return_sequences: int = 1
+    ) -> List[str]:
+        """Return a list of generated code actions."""
+        if self.pipeline is None:
+            return []
+        outputs = self.pipeline(
+            prompt, max_new_tokens=max_tokens, num_return_sequences=num_return_sequences
+        )
+        return [o.get("generated_text", "") for o in outputs]

--- a/tests/test_code_llm.py
+++ b/tests/test_code_llm.py
@@ -1,0 +1,20 @@
+from core.code_llm import CodeLLM
+from vision.vision_engine import RLAgent
+
+
+class DummyPipe:
+    def __call__(self, prompt, max_new_tokens=64, num_return_sequences=1):
+        return [{"generated_text": f"{prompt}-action"} for _ in range(num_return_sequences)]
+
+
+def test_code_llm_generates_actions():
+    llm = CodeLLM(pipeline=DummyPipe())
+    actions = llm.generate_actions("def foo(): pass", max_tokens=10)
+    assert actions == ["def foo(): pass-action"]
+
+
+def test_rl_agent_generates_actions():
+    llm = CodeLLM(pipeline=DummyPipe())
+    agent = RLAgent(code_model=llm)
+    actions = agent.generate_code_actions("print('hi')", num_return_sequences=2)
+    assert actions == ["print('hi')-action", "print('hi')-action"]

--- a/vision/vision_engine.py
+++ b/vision/vision_engine.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import List, Dict, Optional
 import json
 
+from core.code_llm import CodeLLM
+
 from core.task import Task
 
 
@@ -61,12 +63,14 @@ class RLAgent:
         self,
         history_path: Optional[Path] = None,
         training_path: Optional[Path] = None,
+        code_model: Optional[CodeLLM] = None,
     ) -> None:
         self.history: List[Dict[str, List[int]]] = []
         self.training_data: List[Dict[str, float]] = []
         self.history_path = Path(history_path) if history_path else None
         self.training_path = Path(training_path) if training_path else None
         self.authority: float = 0.0
+        self.code_model = code_model
 
     def suggest(self, tasks: List[Task]) -> List[Task]:
         """Return refined ordering. Currently identity function."""
@@ -102,3 +106,17 @@ class RLAgent:
     def consolidate(self) -> None:
         """Hook for weight consolidation. No-op for base class."""
         return None
+
+    # --------------------------------------------------------------
+    def generate_code_actions(
+        self, context: str, max_tokens: int = 64, num_return_sequences: int = 1
+    ) -> List[str]:
+        """Return code actions from the associated ``CodeLLM`` if available."""
+
+        if not self.code_model:
+            return []
+        return self.code_model.generate_actions(
+            context,
+            max_tokens=max_tokens,
+            num_return_sequences=num_return_sequences,
+        )


### PR DESCRIPTION
## Summary
- add `CodeLLM` utility to produce code actions via a fine-tuned model
- extend `RLAgent` to use optional `CodeLLM` and expose `generate_code_actions`
- include basic tests for the new module

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionRefusedError in test_autoscaler_processes_queue)*

------
https://chatgpt.com/codex/tasks/task_e_686f4dad56d0832ab6047cc5e6e33b74