### PR TITLE
Implement composite reward function

### DIFF
--- a/core/reward.py
+++ b/core/reward.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Dict, Iterable
+
+
+def calculate_reward(
+    metrics: Dict[str, float],
+    success_weight: float = 1.0,
+    runtime_weight: float = 0.1,
+) -> float:
+    """Return reward based on success and runtime efficiency.
+
+    The function looks for ``success``/``task_success`` and ``runtime``/``duration``
+    keys in ``metrics``. If found, the reward is computed as::
+
+        success_weight * success - runtime_weight * runtime
+
+    where ``success`` is interpreted as ``1`` for ``True``/non-zero and ``0`` otherwise.
+    When neither value is present, the reward falls back to the sum of all numeric
+    metrics.
+    """
+    success_keys: Iterable[str] = ("success", "task_success")
+    runtime_keys: Iterable[str] = ("runtime", "duration")
+
+    success = None
+    runtime = None
+
+    for key in success_keys:
+        if key in metrics:
+            try:
+                success = float(metrics[key])
+            except Exception:
+                success = 0.0
+            break
+
+    for key in runtime_keys:
+        if key in metrics:
+            try:
+                runtime = float(metrics[key])
+            except Exception:
+                runtime = 0.0
+            break
+
+    if success is not None or runtime is not None:
+        if success is None:
+            success = 0.0
+        if runtime is None:
+            runtime = 0.0
+        return success_weight * success - runtime_weight * runtime
+
+    return float(sum(v for v in metrics.values() if isinstance(v, (int, float))))
+
+

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -1,0 +1,13 @@
+from core.reward import calculate_reward
+
+
+def test_reward_with_success_and_runtime():
+    metrics = {"success": True, "runtime": 2.0}
+    r = calculate_reward(metrics, success_weight=1.0, runtime_weight=0.5)
+    assert r == 1.0 - 1.0
+
+
+def test_reward_fallback_sum():
+    metrics = {"coverage": 80, "bugs": 0}
+    assert calculate_reward(metrics) == 80.0
+

--- a/vision/epo/simulation.py
+++ b/vision/epo/simulation.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 from core.observability import MetricsProvider
+from core.reward import calculate_reward
 from ..ppo import ReplayBuffer, StateBuilder, PPOAgent
 from .gene import Gene
 
@@ -28,5 +29,5 @@ class SimulationEnvironment:
         for _ in range(self.episodes):
             metrics = self.metrics_provider.collect()
             agent.train(metrics)
-            total += sum(metrics.get(k, 0.0) for k in metrics if isinstance(metrics[k], (int, float)))
+            total += calculate_reward(metrics)
         return total + sum(agent.value.values())

--- a/vision/ppo/agent.py
+++ b/vision/ppo/agent.py
@@ -7,6 +7,7 @@ from typing import Dict, Optional
 from .replay_buffer import ReplayBuffer
 from .ewc import EWC
 from .state_builder import StateBuilder
+from core.reward import calculate_reward
 
 
 @dataclass
@@ -69,7 +70,7 @@ class PPOAgent:
     # Integration with RLTrainer
     def train(self, metrics: Dict[str, float]) -> None:
         state = self.state_builder.build()
-        reward = sum(metrics.get(k, 0.0) for k in metrics if isinstance(metrics[k], (int, float)))
+        reward = calculate_reward(metrics)
         action = self.select_action(state)
         self.store_transition(state, action, reward, state, True)
         self.update()

--- a/vision/vision_engine.py
+++ b/vision/vision_engine.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import List, Dict, Optional
 import json
 
+from core.reward import calculate_reward
+
 from core.code_llm import CodeLLM
 
 from core.task import Task
@@ -89,9 +91,7 @@ class RLAgent:
 
     def train(self, metrics: Dict[str, float]) -> float:
         """Collect ``metrics`` for offline training and return reward."""
-        reward = sum(
-            v for v in metrics.values() if isinstance(v, (int, float))
-        )
+        reward = calculate_reward(metrics)
         self.training_data.append(metrics)
         if self.training_path:
             with self.training_path.open("a", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- implement `calculate_reward` utility for task success and runtime
- integrate reward calculation into PPO agent, SimulationEnvironment, and RLAgent
- add tests for reward calculation

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: HTTPConnectionPool(host='localhost', port=8010) - ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_686f5713c98c832a905eb2c4eee27961