### PR TITLE
Implement PPO agent with separate policy and value nets

### DIFF
--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -39,7 +39,8 @@ def test_ppo_agent_training_step(tmp_path):
     metrics = provider.collect()
     agent.train(metrics)
     assert len(buffer) == 0
-    assert agent.value  # weights updated
+    assert agent.value  # critic weights updated
+    assert agent.policy  # policy weights updated
 
 
 def test_ppo_consolidation_updates_fisher(tmp_path):


### PR DESCRIPTION
## Summary
- add policy network alongside value network in PPOAgent
- update agent training logic to use PPO-style updates
- adjust tests for new policy/value separation

## Testing
- `pytest --maxfail=1 --disable-warnings -q tests/test_ppo.py tests/test_epo.py`

------
https://chatgpt.com/codex/tasks/task_e_686f629c0dbc832a8fc8b64dcb8cc7de