### PR TITLE
Implement evolutionary PPO hyperparam optimizer

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -297,7 +297,7 @@
   dependencies:
   - 66
   priority: 3
-  status: pending
+  status: done
   area: reflector
   actionable_steps: []
   acceptance_criteria: []
@@ -308,7 +308,7 @@
   dependencies:
   - 67
   priority: 3
-  status: pending
+  status: done
   area: reflector
   actionable_steps: []
   acceptance_criteria: []

--- a/tests/test_epo.py
+++ b/tests/test_epo.py
@@ -33,3 +33,15 @@ def test_two_speed_engine(tmp_path):
     engine.inner_step()
     engine.outer_cycle()
     assert isinstance(engine.gene, Gene)
+
+
+def test_environment_builds_agent_with_gene_params(tmp_path):
+    metrics_file = tmp_path / "m.json"
+    metrics_file.write_text('{"reward": 1}')
+    provider = MetricsProvider(metrics_file)
+    env = SimulationEnvironment(metrics_provider=provider, episodes=1)
+    gene = Gene(hidden_dim=32, learning_rate=0.005, clip_epsilon=0.3, gamma=0.9)
+    agent = env.build_agent(gene)
+    assert agent.learning_rate == gene.learning_rate
+    assert agent.clip_epsilon == gene.clip_epsilon
+    assert agent.gamma == gene.gamma

--- a/vision/epo/gene.py
+++ b/vision/epo/gene.py
@@ -6,11 +6,12 @@ import random
 
 @dataclass
 class Gene:
-    """Simple hyperparameter container for agent variations."""
+    """Hyperparameters defining a PPO agent configuration."""
 
     hidden_dim: int = 64
     learning_rate: float = 0.001
     clip_epsilon: float = 0.2
+    gamma: float = 0.99
 
     def mutate(self) -> Gene:
         """Return a slightly modified copy of this gene."""
@@ -18,6 +19,7 @@ class Gene:
             hidden_dim=max(1, self.hidden_dim + random.randint(-8, 8)),
             learning_rate=max(1e-5, self.learning_rate * random.uniform(0.8, 1.2)),
             clip_epsilon=min(1.0, max(0.01, self.clip_epsilon + random.uniform(-0.05, 0.05))),
+            gamma=min(0.999, max(0.5, self.gamma + random.uniform(-0.05, 0.05))),
         )
 
     def crossover(self, other: Gene) -> Gene:
@@ -26,4 +28,5 @@ class Gene:
             hidden_dim=random.choice([self.hidden_dim, other.hidden_dim]),
             learning_rate=random.choice([self.learning_rate, other.learning_rate]),
             clip_epsilon=random.choice([self.clip_epsilon, other.clip_epsilon]),
+            gamma=random.choice([self.gamma, other.gamma]),
         )

--- a/vision/epo/outer_loop.py
+++ b/vision/epo/outer_loop.py
@@ -20,11 +20,14 @@ class EvolutionaryPolicyOptimizer:
         """Return the best evolved gene starting from ``seed``."""
         population = [seed] + [seed.mutate() for _ in range(self.population_size - 1)]
         best_gene = seed
-        best_score = self.environment.evaluate(seed)
         for _ in range(self.generations):
-            scores = [(self.environment.evaluate(g), g) for g in population]
-            scores.sort(key=lambda x: x[0], reverse=True)
-            best_score, best_gene = scores[0]
-            population = [best_gene] + [best_gene.mutate() for _ in range(self.population_size - 1)]
+            scored = sorted(
+                ((self.environment.evaluate(g), g) for g in population),
+                key=lambda x: x[0],
+                reverse=True,
+            )
+            best_gene = scored[0][1]
             self.history.append(best_gene)
+            parents = [g for _, g in scored[:2]]
+            population = parents + [parents[0].crossover(parents[1]).mutate() for _ in range(self.population_size - 2)]
         return best_gene

--- a/vision/epo/simulation.py
+++ b/vision/epo/simulation.py
@@ -20,7 +20,13 @@ class SimulationEnvironment:
         """Instantiate a PPO agent using ``gene`` hyperparameters."""
         buffer = ReplayBuffer(capacity=gene.hidden_dim)
         builder = StateBuilder(self.metrics_provider)
-        return PPOAgent(state_builder=builder, replay_buffer=buffer, gamma=0.99)
+        return PPOAgent(
+            state_builder=builder,
+            replay_buffer=buffer,
+            gamma=gene.gamma,
+            learning_rate=gene.learning_rate,
+            clip_epsilon=gene.clip_epsilon,
+        )
 
     def evaluate(self, gene: Gene) -> float:
         """Return cumulative reward for agent defined by ``gene``."""


### PR DESCRIPTION
## Summary
- evolve PPO hyperparameters across generations
- hook gene fields into SimulationEnvironment
- refine outer loop algorithm to use crossover
- cover new behavior in unit tests
- mark evolutionary strategy tasks done

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionRefusedError during integration test)*

------
https://chatgpt.com/codex/tasks/task_e_686f6ad70740832ab7c2bd5bd6dd7cb1