### PR TITLE
Implement two-speed training pipeline

### DIFF
--- a/tests/test_two_speed_training.py
+++ b/tests/test_two_speed_training.py
@@ -1,0 +1,22 @@
+from vision import (
+    Gene,
+    EvolutionaryPolicyOptimizer,
+    SimulationEnvironment,
+    TwoSpeedEngine,
+    TwoSpeedTrainer,
+)
+from core.observability import MetricsProvider
+
+
+def test_two_speed_trainer(tmp_path):
+    metrics_file = tmp_path / "metrics.json"
+    metrics_file.write_text('{"reward": 1}')
+    provider = MetricsProvider(metrics_file)
+    env = SimulationEnvironment(metrics_provider=provider, episodes=1)
+    gene = Gene()
+    optimizer = EvolutionaryPolicyOptimizer(environment=env, generations=1)
+    agent = env.build_agent(gene)
+    engine = TwoSpeedEngine(inner_agent=agent, outer_loop=optimizer, gene=gene)
+    trainer = TwoSpeedTrainer(engine=engine, inner_steps=2)
+    trainer.run(cycles=1)
+    assert isinstance(trainer.engine.gene, Gene)

--- a/vision/__init__.py
+++ b/vision/__init__.py
@@ -1,7 +1,7 @@
 """Vision Engine package."""
 
 from .vision_engine import VisionEngine, RLAgent, wsjf_score
-from .training import RLTrainer
+from .training import RLTrainer, TwoSpeedTrainer
 from .ppo import ReplayBuffer, EWC, StateBuilder, PPOAgent
 from .epo import (
     Gene,
@@ -15,6 +15,7 @@ __all__ = [
     "RLAgent",
     "wsjf_score",
     "RLTrainer",
+    "TwoSpeedTrainer",
     "ReplayBuffer",
     "EWC",
     "StateBuilder",

--- a/vision/training.py
+++ b/vision/training.py
@@ -8,6 +8,7 @@ from prometheus_client import Gauge, start_http_server
 
 from core.observability import MetricsProvider
 from .vision_engine import RLAgent
+from .epo import TwoSpeedEngine
 
 REWARD_GAUGE = Gauge("rl_training_reward", "Reward for the last episode")
 LENGTH_GAUGE = Gauge("rl_training_episode_length", "Steps in the last episode")
@@ -37,3 +38,18 @@ class RLTrainer:
                     pass
             REWARD_GAUGE.set(reward)
             LENGTH_GAUGE.set(len(metrics))
+
+
+@dataclass
+class TwoSpeedTrainer:
+    """Coordinate PPO inner loop and evolutionary outer loop."""
+
+    engine: TwoSpeedEngine
+    inner_steps: int = 1
+
+    def run(self, cycles: int = 1) -> None:
+        """Run ``inner_steps`` and then an outer-loop cycle for each iteration."""
+        for _ in range(cycles):
+            for _ in range(self.inner_steps):
+                self.engine.inner_step()
+            self.engine.outer_cycle()


### PR DESCRIPTION
## Summary
- implement `TwoSpeedTrainer` to couple PPO inner loop with evolutionary outer loop
- expose new trainer via `vision.__init__`
- test `TwoSpeedTrainer` integration

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionRefusedError)*

------
https://chatgpt.com/codex/tasks/task_e_686f70470c80832a84a8b0d417bb321d