### PR TITLE
Add ReplayBuffer to reflector RL

### DIFF
--- a/reflector/__init__.py
+++ b/reflector/__init__.py
@@ -1,0 +1,5 @@
+"""Reflector package with reinforcement learning utilities."""
+
+from .rl import ReplayBuffer, PPOAgent
+
+__all__ = ["ReplayBuffer", "PPOAgent"]

--- a/reflector/rl/__init__.py
+++ b/reflector/rl/__init__.py
@@ -1,0 +1,6 @@
+"""Reinforcement learning helpers for the Reflector."""
+
+from .experience import ReplayBuffer
+from .training import PPOAgent
+
+__all__ = ["ReplayBuffer", "PPOAgent"]

--- a/reflector/rl/experience.py
+++ b/reflector/rl/experience.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, List, Tuple
+import random
+
+
+@dataclass
+class ReplayBuffer:
+    """Fixed-size experience replay buffer."""
+
+    capacity: int
+    buffer: List[Tuple[Any, ...]] = field(default_factory=list)
+
+    def add(self, transition: Tuple[Any, ...]) -> None:
+        """Store ``transition`` and evict oldest when over capacity."""
+        if len(self.buffer) >= self.capacity:
+            self.buffer.pop(0)
+        self.buffer.append(transition)
+
+    def sample(self, batch_size: int) -> List[Tuple[Any, ...]]:
+        """Return a random mini-batch of experiences."""
+        if not self.buffer:
+            return []
+        return random.sample(self.buffer, min(batch_size, len(self.buffer)))
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self.buffer)

--- a/reflector/rl/training.py
+++ b/reflector/rl/training.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+import math
+import random
+
+from .experience import ReplayBuffer
+
+
+@dataclass
+class PPOAgent:
+    """Minimal PPO agent storing experiences in a replay buffer."""
+
+    replay_buffer: ReplayBuffer
+    gamma: float = 0.99
+    learning_rate: float = 0.01
+    policy: Dict[str, float] = field(default_factory=dict)
+
+    def select_action(self, state: Dict[str, float]) -> tuple[int, float]:
+        z = sum(state.get(k, 0.0) * self.policy.get(k, 0.0) for k in state)
+        p = 1.0 / (1.0 + math.exp(-z))
+        action = 1 if random.random() < p else 0
+        log_prob = math.log(p if action == 1 else 1.0 - p + 1e-8)
+        return action, log_prob
+
+    def train_step(self, state: Dict[str, float], reward: float) -> None:
+        action, log_prob = self.select_action(state)
+        self.replay_buffer.add((state, action, reward, state, True, log_prob))
+        batch = self.replay_buffer.sample(batch_size=4)
+        if not batch:
+            return
+        for s, a, r, _ns, _done, _lp in batch:
+            z = sum(s.get(k, 0.0) * self.policy.get(k, 0.0) for k in s)
+            p = 1.0 / (1.0 + math.exp(-z))
+            advantage = r - p
+            for k, v in s.items():
+                grad = (1 - p) * v if a == 1 else -p * v
+                self.policy[k] = self.policy.get(k, 0.0) + self.learning_rate * advantage * grad
+        self.replay_buffer.buffer.clear()

--- a/tests/test_reflector_rl.py
+++ b/tests/test_reflector_rl.py
@@ -1,0 +1,23 @@
+from reflector.rl import ReplayBuffer, PPOAgent
+import random
+
+
+def test_replay_buffer_add_and_sample():
+    buf = ReplayBuffer(capacity=2)
+    buf.add((1, 2))
+    buf.add((2, 3))
+    buf.add((3, 4))
+    assert len(buf) == 2
+    sample = buf.sample(1)
+    assert len(sample) == 1
+    assert sample[0] in [(2, 3), (3, 4)]
+
+
+def test_ppo_agent_updates_policy_and_clears_buffer():
+    random.seed(0)
+    buf = ReplayBuffer(capacity=4)
+    agent = PPOAgent(replay_buffer=buf)
+    state = {"x": 1.0}
+    agent.train_step(state, reward=1.0)
+    assert len(buf) == 0
+    assert agent.policy


### PR DESCRIPTION
## Summary
- implement `ReplayBuffer` for reflector RL
- integrate buffer with `PPOAgent`
- add unit tests for storing and sampling experiences

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686f780bd854832a9d1c93ba54cfd392