### PR TITLE
Implement metrics-based state builder for Reflector

### DIFF
--- a/reflector/__init__.py
+++ b/reflector/__init__.py
@@ -1,5 +1,6 @@
 """Reflector package with reinforcement learning utilities."""
 
 from .rl import ReplayBuffer, PPOAgent
+from .state_builder import StateBuilder
 
-__all__ = ["ReplayBuffer", "PPOAgent"]
+__all__ = ["ReplayBuffer", "PPOAgent", "StateBuilder"]

--- a/reflector/state_builder.py
+++ b/reflector/state_builder.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from core.observability import MetricsProvider
+
+
+class StateBuilder:
+    """Generate a state vector from observability metrics."""
+
+    def __init__(self, metrics_provider: MetricsProvider) -> None:
+        self.metrics_provider = metrics_provider
+
+    def build(self) -> Dict[str, float]:
+        """Return numeric metrics of interest with defaults."""
+        metrics = self.metrics_provider.collect()
+        cpu = float(metrics.get("cpu", 0))
+        memory = float(metrics.get("memory", 0))
+        error_rate = float(metrics.get("error_rate", 0))
+        state = {
+            "cpu": cpu,
+            "memory": memory,
+            "error_rate": error_rate,
+        }
+        return state
+
+    def vector(self) -> list[float]:
+        """Return ``build()`` values sorted by key for stable ordering."""
+        state = self.build()
+        return [state[k] for k in sorted(state.keys())]

--- a/tests/test_reflector_rl.py
+++ b/tests/test_reflector_rl.py
@@ -1,4 +1,8 @@
+from typing import Dict
+
 from reflector.rl import ReplayBuffer, PPOAgent, EWC
+from reflector import StateBuilder
+from core.observability import MetricsProvider
 import random
 
 
@@ -13,42 +17,56 @@ def test_replay_buffer_add_and_sample():
     assert sample[0] in [(2, 3), (3, 4)]
 
 
-def test_ppo_agent_updates_policy_and_clears_buffer():
+def test_ppo_agent_updates_policy_and_clears_buffer(tmp_path):
     random.seed(0)
+    metrics_file = tmp_path / "m.json"
+    metrics_file.write_text('{"cpu": 0.1, "memory": 0.2, "error_rate": 0.0, "success": 1}')
+    provider = MetricsProvider(metrics_file)
+    builder = StateBuilder(provider)
     buf = ReplayBuffer(capacity=4)
-    agent = PPOAgent(replay_buffer=buf)
-    state = {"x": 1.0}
-    agent.train_step(state, reward=1.0)
+    agent = PPOAgent(replay_buffer=buf, state_builder=builder)
+    metrics = provider.collect()
+    agent.train_step(metrics)
     assert len(buf) == 0
     assert agent.policy
 
 
-def _train(agent: PPOAgent, reward: float, steps: int = 5) -> None:
-    state = {"x": 1.0}
+def _train(agent: PPOAgent, metrics: Dict[str, float], steps: int = 5) -> None:
     for _ in range(steps):
-        agent.train_step(state, reward)
+        agent.train_step(metrics)
 
 
-def test_ewc_reduces_catastrophic_forgetting():
+def test_ewc_reduces_catastrophic_forgetting(tmp_path):
     random.seed(0)
+    metrics_file = tmp_path / "m.json"
+    metrics_file.write_text('{"cpu": 0.1, "memory": 0.2, "error_rate": 0.0, "success": 1, "runtime": 1}')
+    provider = MetricsProvider(metrics_file)
+    builder = StateBuilder(provider)
     # Agent without EWC
     buf1 = ReplayBuffer(capacity=10)
-    agent_no_ewc = PPOAgent(replay_buffer=buf1)
-    _train(agent_no_ewc, reward=1.0)
-    weight_a = agent_no_ewc.policy.get("x", 0.0)
-    _train(agent_no_ewc, reward=-1.0)
-    weight_b = agent_no_ewc.policy.get("x", 0.0)
+    agent_no_ewc = PPOAgent(replay_buffer=buf1, state_builder=builder)
+    pos_metrics = provider.collect()
+    _train(agent_no_ewc, pos_metrics)
+    weight_a = agent_no_ewc.policy.get("cpu", 0.0)
+    metrics_file.write_text('{"cpu": 0.1, "memory": 0.2, "error_rate": 0.0, "success": 0, "runtime": 1}')
+    neg_metrics = provider.collect()
+    _train(agent_no_ewc, neg_metrics)
+    weight_b = agent_no_ewc.policy.get("cpu", 0.0)
     forgetting_without = abs(weight_b - weight_a)
 
     # Agent with EWC
     buf2 = ReplayBuffer(capacity=10)
     ewc = EWC()
-    agent_ewc = PPOAgent(replay_buffer=buf2, ewc=ewc)
-    _train(agent_ewc, reward=1.0)
+    agent_ewc = PPOAgent(replay_buffer=buf2, state_builder=builder, ewc=ewc)
+    metrics_file.write_text('{"cpu": 0.1, "memory": 0.2, "error_rate": 0.0, "success": 1, "runtime": 1}')
+    pos_metrics = provider.collect()
+    _train(agent_ewc, pos_metrics)
     agent_ewc.consolidate()
-    weight_a_ewc = agent_ewc.policy.get("x", 0.0)
-    _train(agent_ewc, reward=-1.0)
-    weight_b_ewc = agent_ewc.policy.get("x", 0.0)
+    weight_a_ewc = agent_ewc.policy.get("cpu", 0.0)
+    metrics_file.write_text('{"cpu": 0.1, "memory": 0.2, "error_rate": 0.0, "success": 0, "runtime": 1}')
+    neg_metrics = provider.collect()
+    _train(agent_ewc, neg_metrics)
+    weight_b_ewc = agent_ewc.policy.get("cpu", 0.0)
     forgetting_with = abs(weight_b_ewc - weight_a_ewc)
 
     assert forgetting_with < forgetting_without


### PR DESCRIPTION
## Summary
- derive state vector from CPU, memory and error rate
- expose `StateBuilder` from `reflector`
- integrate `StateBuilder` with Reflector PPO agent
- update RL tests to use new metrics-based state vectors

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686f8f9f676c832a869e1928802bd42b