### PR TITLE
Implement code LLM action generator

### DIFF
--- a/reflector/rl/__init__.py
+++ b/reflector/rl/__init__.py
@@ -3,5 +3,6 @@
 from .experience import ReplayBuffer
 from .training import PPOAgent
 from .ewc import EWC
+from .gen_actions import ActionGenerator
 
-__all__ = ["ReplayBuffer", "PPOAgent", "EWC"]
+__all__ = ["ReplayBuffer", "PPOAgent", "EWC", "ActionGenerator"]

--- a/reflector/rl/gen_actions.py
+++ b/reflector/rl/gen_actions.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+"""Generate code patches using a fine-tuned LLM."""
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from core.code_llm import CodeLLM
+
+
+@dataclass
+class ActionGenerator:
+    """Wrapper around :class:`CodeLLM` for patch generation."""
+
+    model_path: str = "distilgpt2"
+    llm: Optional[CodeLLM] = None
+
+    def __post_init__(self) -> None:
+        if self.llm is None:
+            self.llm = CodeLLM(model_name=self.model_path)
+
+    def propose(self, context: str, max_tokens: int = 64, num_actions: int = 1) -> List[str]:
+        """Return ``num_actions`` proposed code patches for ``context``."""
+        if not self.llm:
+            return []
+        return self.llm.generate_actions(
+            context, max_tokens=max_tokens, num_return_sequences=num_actions
+        )
+

--- a/reflector/rl/training.py
+++ b/reflector/rl/training.py
@@ -5,6 +5,7 @@ from typing import Dict, Optional
 
 from ..state_builder import StateBuilder
 from core.reward import calculate_reward
+from .gen_actions import ActionGenerator
 import math
 import random
 
@@ -21,6 +22,7 @@ class PPOAgent:
     ewc: Optional[EWC] = None
     gamma: float = 0.99
     learning_rate: float = 0.01
+    action_gen: Optional[ActionGenerator] = None
     policy: Dict[str, float] = field(default_factory=dict)
 
     def select_action(self, state: Dict[str, float]) -> tuple[int, float]:
@@ -60,3 +62,10 @@ class PPOAgent:
     def consolidate(self) -> None:
         if self.ewc:
             self.ewc.update_importance(self.policy)
+
+    def propose_patch(self, context: str, max_tokens: int = 64) -> str:
+        """Return a code patch proposal generated from ``context``."""
+        if not self.action_gen:
+            return ""
+        patches = self.action_gen.propose(context, max_tokens=max_tokens)
+        return patches[0] if patches else ""

--- a/scripts/fine_tune_code_llm.py
+++ b/scripts/fine_tune_code_llm.py
@@ -1,0 +1,64 @@
+"""Fine-tune a lightweight code LLM on repository patches."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+from git import Repo
+
+
+def collect_patches(repo_path: Path, max_commits: int = 100) -> List[str]:
+    """Return ``max_commits`` most recent commit patches."""
+    repo = Repo(repo_path)
+    patches = []
+    for commit in repo.iter_commits("HEAD", max_count=max_commits):
+        patches.append(repo.git.show(commit.hexsha, format="", patches=True))
+    return patches
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=Path, help="Directory for fine-tuned model")
+    parser.add_argument("--commits", type=int, default=100)
+    parser.add_argument("--model", default="distilgpt2")
+    args = parser.parse_args()
+
+    patches = collect_patches(Path.cwd(), args.commits)
+
+    from transformers import (
+        AutoTokenizer,
+        AutoModelForCausalLM,
+        Trainer,
+        TrainingArguments,
+        DataCollatorForLanguageModeling,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    model = AutoModelForCausalLM.from_pretrained(args.model)
+
+    encodings = tokenizer(patches, truncation=True, padding=True)
+    class PatchDataset:
+        def __init__(self, encs):
+            self.encs = encs
+        def __len__(self):
+            return len(self.encs["input_ids"])
+        def __getitem__(self, idx):
+            item = {k: v[idx] for k, v in self.encs.items()}
+            item["labels"] = item["input_ids"]
+            return item
+
+    dataset = PatchDataset(encodings)
+    args_train = TrainingArguments(output_dir=str(args.output), num_train_epochs=1, per_device_train_batch_size=1)
+    trainer = Trainer(
+        model=model,
+        args=args_train,
+        data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False),
+        train_dataset=dataset,
+    )
+    trainer.train()
+    trainer.save_model(str(args.output))
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI
+    main()

--- a/tasks.yml
+++ b/tasks.yml
@@ -262,7 +262,7 @@
   dependencies:
   - 63
   priority: 3
-  status: pending
+  status: done
   area: reflector
   actionable_steps: []
   acceptance_criteria: []

--- a/tests/test_gen_actions.py
+++ b/tests/test_gen_actions.py
@@ -1,0 +1,27 @@
+from core.code_llm import CodeLLM
+from reflector.rl.gen_actions import ActionGenerator
+from reflector.rl import PPOAgent, ReplayBuffer
+from reflector import StateBuilder
+from core.observability import MetricsProvider
+
+class DummyPipe:
+    def __call__(self, prompt, max_new_tokens=64, num_return_sequences=1):
+        return [{"generated_text": "patch"} for _ in range(num_return_sequences)]
+
+
+def test_action_generator_produces_patch():
+    ag = ActionGenerator(llm=CodeLLM(pipeline=DummyPipe()))
+    patches = ag.propose("context")
+    assert patches == ["patch"]
+
+
+def test_ppo_agent_proposes_patch(tmp_path):
+    metrics_file = tmp_path / "m.json"
+    metrics_file.write_text('{"cpu": 0}')
+    provider = MetricsProvider(metrics_file)
+    builder = StateBuilder(provider)
+    buf = ReplayBuffer(capacity=1)
+    ag = ActionGenerator(llm=CodeLLM(pipeline=DummyPipe()))
+    agent = PPOAgent(replay_buffer=buf, state_builder=builder, action_gen=ag)
+    patch = agent.propose_patch("def foo(): pass")
+    assert patch == "patch"


### PR DESCRIPTION
## Summary
- train lightweight code LLM on git patches
- generate code patches with ActionGenerator
- allow PPOAgent to propose patches
- mark generative action space task done
- add tests for ActionGenerator

## Testing
- `pytest -k "not integration" --maxfail=1 --disable-warnings -q` *(fails: opentelemetry instrumentation missing / long-running tests)*

------
https://chatgpt.com/codex/tasks/task_e_686f93ef9df8832ab2e41829fd10967c