### PR TITLE
Add weighted RL reward

### DIFF
--- a/reflector/rl/__init__.py
+++ b/reflector/rl/__init__.py
@@ -4,5 +4,14 @@ from .experience import ReplayBuffer
 from .training import PPOAgent
 from .ewc import EWC
 from .gen_actions import ActionGenerator
+from .reward import calculate_reward, reward_terms, DEFAULT_WEIGHTS
 
-__all__ = ["ReplayBuffer", "PPOAgent", "EWC", "ActionGenerator"]
+__all__ = [
+    "ReplayBuffer",
+    "PPOAgent",
+    "EWC",
+    "ActionGenerator",
+    "calculate_reward",
+    "reward_terms",
+    "DEFAULT_WEIGHTS",
+]

--- a/reflector/rl/reward.py
+++ b/reflector/rl/reward.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+"""Reward calculation helpers for RL training."""
+
+from typing import Dict, Tuple
+
+# Default weights for each reward component
+DEFAULT_WEIGHTS = {
+    "correctness": 1.0,
+    "performance": 0.5,
+    "style": 0.2,
+}
+
+
+def reward_terms(metrics: Dict[str, float]) -> Dict[str, float]:
+    """Extract reward components from ``metrics``.
+
+    - ``correctness`` derives from ``success`` or ``task_success``.
+    - ``performance`` is the negative runtime or duration.
+    - ``style`` uses ``style`` or ``style_score`` metrics.
+    """
+    correctness_keys = ("correctness", "success", "task_success")
+    runtime_keys = ("runtime", "duration")
+    style_keys = ("style", "style_score")
+
+    correctness = 0.0
+    for key in correctness_keys:
+        if key in metrics:
+            try:
+                correctness = float(metrics[key])
+            except Exception:
+                correctness = 1.0 if metrics[key] else 0.0
+            break
+
+    performance = 0.0
+    for key in runtime_keys:
+        if key in metrics:
+            try:
+                performance = -float(metrics[key])
+            except Exception:
+                performance = 0.0
+            break
+
+    style = 0.0
+    for key in style_keys:
+        if key in metrics:
+            try:
+                style = float(metrics[key])
+            except Exception:
+                style = 0.0
+            break
+
+    return {
+        "correctness": correctness,
+        "performance": performance,
+        "style": style,
+    }
+
+
+def calculate_reward(
+    metrics: Dict[str, float], weights: Dict[str, float] | None = None
+) -> Tuple[float, Dict[str, float]]:
+    """Return weighted reward and component terms."""
+    terms = reward_terms(metrics)
+    w = weights or DEFAULT_WEIGHTS
+    reward = sum(w.get(k, 0.0) * v for k, v in terms.items())
+    return reward, terms
+
+__all__ = ["reward_terms", "calculate_reward", "DEFAULT_WEIGHTS"]

--- a/reflector/rl/training.py
+++ b/reflector/rl/training.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 from typing import Dict, Optional
 
 from ..state_builder import StateBuilder
-from core.reward import calculate_reward
+from .reward import calculate_reward
 from .gen_actions import ActionGenerator
 import math
 import random
@@ -35,7 +35,7 @@ class PPOAgent:
     def train_step(self, metrics: Dict[str, float]) -> None:
         """Update policy using ``metrics`` and the current state."""
         state = self.state_builder.build()
-        reward = calculate_reward(metrics)
+        reward, _terms = calculate_reward(metrics)
         action, log_prob = self.select_action(state)
         self.replay_buffer.add((state, action, reward, state, True, log_prob))
         batch = self.replay_buffer.sample(batch_size=4)

--- a/tests/test_rl_reward.py
+++ b/tests/test_rl_reward.py
@@ -1,0 +1,15 @@
+from reflector.rl.reward import calculate_reward, reward_terms, DEFAULT_WEIGHTS
+
+
+def test_reward_terms_extraction():
+    metrics = {"success": True, "runtime": 2.0, "style_score": 0.5}
+    terms = reward_terms(metrics)
+    assert terms["correctness"] == 1.0
+    assert terms["performance"] == -2.0
+    assert terms["style"] == 0.5
+
+
+def test_weighted_reward():
+    metrics = {"success": 1, "runtime": 1, "style_score": 1}
+    reward, _ = calculate_reward(metrics, weights={"correctness": 1, "performance": 1, "style": 1})
+    assert reward == 1 - 1 + 1

--- a/vision/epo/simulation.py
+++ b/vision/epo/simulation.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 from core.observability import MetricsProvider
-from core.reward import calculate_reward
+from reflector.rl.reward import calculate_reward
 from ..ppo import ReplayBuffer, StateBuilder, PPOAgent
 from .gene import Gene
 
@@ -35,5 +35,6 @@ class SimulationEnvironment:
         for _ in range(self.episodes):
             metrics = self.metrics_provider.collect()
             agent.train(metrics)
-            total += calculate_reward(metrics)
+            reward, _terms = calculate_reward(metrics)
+            total += reward
         return total + sum(agent.value.values())

--- a/vision/ppo/agent.py
+++ b/vision/ppo/agent.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional
 from .replay_buffer import ReplayBuffer
 from .ewc import EWC
 from .state_builder import StateBuilder
-from core.reward import calculate_reward
+from reflector.rl.reward import calculate_reward
 
 
 @dataclass
@@ -95,7 +95,7 @@ class PPOAgent:
     # Integration with RLTrainer
     def train(self, metrics: Dict[str, float]) -> None:
         state = self.state_builder.build()
-        reward = calculate_reward(metrics)
+        reward, _terms = calculate_reward(metrics)
         action, log_prob = self.select_action(state)
         self.store_transition(state, action, reward, state, True, log_prob)
         self.update()

--- a/vision/training.py
+++ b/vision/training.py
@@ -12,6 +12,13 @@ from .epo import TwoSpeedEngine
 
 REWARD_GAUGE = Gauge("rl_training_reward", "Reward for the last episode")
 LENGTH_GAUGE = Gauge("rl_training_episode_length", "Steps in the last episode")
+CORRECTNESS_GAUGE = Gauge(
+    "rl_training_correctness", "Correctness component of the reward"
+)
+PERFORMANCE_GAUGE = Gauge(
+    "rl_training_performance", "Performance component of the reward"
+)
+STYLE_GAUGE = Gauge("rl_training_style", "Style component of the reward")
 
 
 @dataclass
@@ -38,6 +45,10 @@ class RLTrainer:
                     pass
             REWARD_GAUGE.set(reward)
             LENGTH_GAUGE.set(len(metrics))
+            terms = getattr(self.agent, "last_reward_terms", {})
+            CORRECTNESS_GAUGE.set(terms.get("correctness", 0.0))
+            PERFORMANCE_GAUGE.set(terms.get("performance", 0.0))
+            STYLE_GAUGE.set(terms.get("style", 0.0))
 
 
 @dataclass

--- a/vision/vision_engine.py
+++ b/vision/vision_engine.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import List, Dict, Optional
 import json
 
-from core.reward import calculate_reward
+from reflector.rl.reward import calculate_reward
 
 from core.code_llm import CodeLLM
 
@@ -73,6 +73,7 @@ class RLAgent:
         self.training_path = Path(training_path) if training_path else None
         self.authority: float = 0.0
         self.code_model = code_model
+        self.last_reward_terms: Dict[str, float] = {}
 
     def suggest(self, tasks: List[Task]) -> List[Task]:
         """Return refined ordering. Currently identity function."""
@@ -91,7 +92,8 @@ class RLAgent:
 
     def train(self, metrics: Dict[str, float]) -> float:
         """Collect ``metrics`` for offline training and return reward."""
-        reward = calculate_reward(metrics)
+        reward, terms = calculate_reward(metrics)
+        self.last_reward_terms = terms
         self.training_data.append(metrics)
         if self.training_path:
             with self.training_path.open("a", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary
- create RL reward helper with correctness, performance and style
- log reward components in RL training
- expose reward utilities via `reflector.rl`
- update PPO agents to use new weighted reward
- test reward calculations

## Testing
- `pytest tests/test_rl_reward.py -q`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionRefusedError when testing autoscaler)*

------
https://chatgpt.com/codex/tasks/task_e_686f9db8c760832aa60066470ed88fe9