### PR TITLE
Add JSON gene encoding and tests

### DIFF
--- a/tests/test_epo.py
+++ b/tests/test_epo.py
@@ -40,7 +40,7 @@ def test_environment_builds_agent_with_gene_params(tmp_path):
     metrics_file.write_text('{"reward": 1}')
     provider = MetricsProvider(metrics_file)
     env = SimulationEnvironment(metrics_provider=provider, episodes=1)
-    gene = Gene(hidden_dim=32, learning_rate=0.005, clip_epsilon=0.3, gamma=0.9)
+    gene = Gene(architecture=(32,), learning_rate=0.005, clip_epsilon=0.3, gamma=0.9)
     agent = env.build_agent(gene)
     assert agent.learning_rate == gene.learning_rate
     assert agent.clip_epsilon == gene.clip_epsilon

--- a/tests/test_gene_serialization.py
+++ b/tests/test_gene_serialization.py
@@ -1,0 +1,19 @@
+from vision.epo import Gene
+
+
+def test_gene_json_roundtrip(tmp_path):
+    gene = Gene(architecture=(32, 16), learning_rate=0.002, clip_epsilon=0.1, gamma=0.95)
+    path = tmp_path / "gene.json"
+    gene.to_json(path)
+    loaded = Gene.from_json(path)
+    assert gene == loaded
+
+
+def test_gene_mutation_ranges():
+    gene = Gene()
+    mutated = gene.mutate()
+    assert all(1 <= l <= 256 for l in mutated.architecture)
+    assert mutated.learning_rate >= 1e-5
+    assert 0.01 <= mutated.clip_epsilon <= 1.0
+    assert 0.5 <= mutated.gamma <= 0.999
+

--- a/vision/epo/gene.py
+++ b/vision/epo/gene.py
@@ -1,22 +1,28 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 import random
+from pathlib import Path
+from typing import Tuple
 
 
 @dataclass
 class Gene:
-    """Hyperparameters defining a PPO agent configuration."""
+    """Hyperparameters and architecture for a PPO agent."""
 
-    hidden_dim: int = 64
+    architecture: Tuple[int, ...] = (64,)
     learning_rate: float = 0.001
     clip_epsilon: float = 0.2
     gamma: float = 0.99
 
     def mutate(self) -> Gene:
         """Return a slightly modified copy of this gene."""
+        layers = [
+            max(1, min(256, l + random.randint(-8, 8))) for l in self.architecture
+        ]
         return Gene(
-            hidden_dim=max(1, self.hidden_dim + random.randint(-8, 8)),
+            architecture=tuple(layers),
             learning_rate=max(1e-5, self.learning_rate * random.uniform(0.8, 1.2)),
             clip_epsilon=min(1.0, max(0.01, self.clip_epsilon + random.uniform(-0.05, 0.05))),
             gamma=min(0.999, max(0.5, self.gamma + random.uniform(-0.05, 0.05))),
@@ -24,9 +30,44 @@ class Gene:
 
     def crossover(self, other: Gene) -> Gene:
         """Combine attributes from this gene and ``other``."""
+        arch = tuple(
+            random.choice([a, b]) for a, b in zip(self.architecture, other.architecture)
+        )
         return Gene(
-            hidden_dim=random.choice([self.hidden_dim, other.hidden_dim]),
+            architecture=arch,
             learning_rate=random.choice([self.learning_rate, other.learning_rate]),
             clip_epsilon=random.choice([self.clip_epsilon, other.clip_epsilon]),
             gamma=random.choice([self.gamma, other.gamma]),
         )
+
+    @property
+    def hidden_dim(self) -> int:
+        """Convenience accessor for the last layer size."""
+        return self.architecture[-1]
+
+    def to_dict(self) -> dict:
+        return {
+            "architecture": list(self.architecture),
+            "learning_rate": self.learning_rate,
+            "clip_epsilon": self.clip_epsilon,
+            "gamma": self.gamma,
+        }
+
+    def to_json(self, path: Path) -> None:
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Gene:
+        return cls(
+            architecture=tuple(data["architecture"]),
+            learning_rate=data["learning_rate"],
+            clip_epsilon=data["clip_epsilon"],
+            gamma=data["gamma"],
+        )
+
+    @classmethod
+    def from_json(cls, path: Path) -> Gene:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls.from_dict(data)


### PR DESCRIPTION
## Summary
- extend `Gene` to include network architecture
- allow serializing/deserializing genes via JSON
- update simulation tests to new API
- ensure mutation ranges are validated

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_686fac53889c832aa6c39034251b793e