### PR TITLE
Add Fisher-aware EWC for PPO

### DIFF
--- a/reflector/rl/ewc.py
+++ b/reflector/rl/ewc.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Iterable, Optional, Tuple
+
+import math
 
 
 @dataclass
@@ -21,8 +23,38 @@ class EWC:
             penalty += importance * (value - opt) ** 2
         return self.lambda_ * penalty
 
-    def update_importance(self, params: Dict[str, float]) -> None:
+    def _estimate_fisher(
+        self,
+        batch: Iterable[Tuple[Dict[str, float], int, float, Dict[str, float], bool, float]],
+        params: Dict[str, float],
+    ) -> Dict[str, float]:
+        """Return diagonal Fisher information estimate for ``params``."""
+        fisher: Dict[str, float] = {k: 0.0 for k in params}
+        count = 0
+        for state, action, _r, _ns, _done, _lp in batch:
+            z = sum(state.get(k, 0.0) * params.get(k, 0.0) for k in state)
+            p = 1.0 / (1.0 + math.exp(-z))
+            for k, v in state.items():
+                grad = (1 - p) * v if action == 1 else -p * v
+                fisher[k] += grad ** 2
+            count += 1
+        if count:
+            for k in fisher:
+                fisher[k] /= count
+        return fisher
+
+    def update_importance(
+        self,
+        params: Dict[str, float],
+        batch: Optional[
+            Iterable[Tuple[Dict[str, float], int, float, Dict[str, float], bool, float]]
+        ] = None,
+    ) -> None:
         """Update Fisher information approximation."""
-        for name, value in params.items():
-            self.fisher[name] = self.fisher.get(name, 0.0) + value ** 2
+        if batch is not None:
+            fisher = self._estimate_fisher(batch, params)
+        else:
+            fisher = {name: value ** 2 for name, value in params.items()}
+        for name, value in fisher.items():
+            self.fisher[name] = self.fisher.get(name, 0.0) + value
         self.opt_params = params.copy()

--- a/vision/ppo/agent.py
+++ b/vision/ppo/agent.py
@@ -23,6 +23,7 @@ class PPOAgent:
     clip_epsilon: float = 0.2
     policy: Dict[str, float] = field(default_factory=dict)
     value: Dict[str, float] = field(default_factory=dict)
+    last_batch: list = field(default_factory=list)
 
     def select_action(self, state: Dict[str, float]) -> tuple[int, float]:
         """Return an action and its log probability under the current policy."""
@@ -50,6 +51,7 @@ class PPOAgent:
         batch = self.replay_buffer.sample(batch_size)
         if not batch:
             return
+        self.last_batch = batch
 
         penalty_grad = {}
         if self.ewc:
@@ -90,7 +92,7 @@ class PPOAgent:
 
     def consolidate(self) -> None:
         if self.ewc:
-            self.ewc.update_importance(self.value)
+            self.ewc.update_importance(self.value, batch=self.last_batch)
 
     # Integration with RLTrainer
     def train(self, metrics: Dict[str, float]) -> None:

--- a/vision/ppo/ewc.py
+++ b/vision/ppo/ewc.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict
+from typing import Dict, Iterable, Optional, Tuple
+
+import math
 
 
 @dataclass
@@ -21,8 +23,38 @@ class EWC:
             penalty += importance * (value - opt) ** 2
         return self.lambda_ * penalty
 
-    def update_importance(self, params: Dict[str, float]) -> None:
+    def _estimate_fisher(
+        self,
+        batch: Iterable[Tuple[Dict[str, float], int, float, Dict[str, float], bool, float]],
+        params: Dict[str, float],
+    ) -> Dict[str, float]:
+        """Return diagonal Fisher information estimate for ``params``."""
+        fisher: Dict[str, float] = {k: 0.0 for k in params}
+        count = 0
+        for state, action, _r, _ns, _done, _lp in batch:
+            z = sum(state.get(k, 0.0) * params.get(k, 0.0) for k in state)
+            p = 1.0 / (1.0 + math.exp(-z))
+            for k, v in state.items():
+                grad = (1 - p) * v if action == 1 else -p * v
+                fisher[k] += grad ** 2
+            count += 1
+        if count:
+            for k in fisher:
+                fisher[k] /= count
+        return fisher
+
+    def update_importance(
+        self,
+        params: Dict[str, float],
+        batch: Optional[
+            Iterable[Tuple[Dict[str, float], int, float, Dict[str, float], bool, float]]
+        ] = None,
+    ) -> None:
         """Update Fisher information approximation."""
-        for name, value in params.items():
-            self.fisher[name] = self.fisher.get(name, 0.0) + value ** 2
+        if batch is not None:
+            fisher = self._estimate_fisher(batch, params)
+        else:
+            fisher = {name: value ** 2 for name, value in params.items()}
+        for name, value in fisher.items():
+            self.fisher[name] = self.fisher.get(name, 0.0) + value
         self.opt_params = params.copy()


### PR DESCRIPTION
## Summary
- extend EWC to compute Fisher information from experience batches
- track latest batch in PPO agents for consolidation
- apply Fisher-based EWC penalties when consolidating PPO weights

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionRefusedError during integration test)*

------
https://chatgpt.com/codex/tasks/task_e_686fbfdd0a34832aa218fde8ea4e15c4