### PR TITLE
Add metrics+log state vector

### DIFF
--- a/tests/test_ppo.py
+++ b/tests/test_ppo.py
@@ -24,7 +24,7 @@ def test_state_builder_numeric_filter(tmp_path):
     provider = MetricsProvider(metrics_file)
     builder = StateBuilder(provider)
     state = builder.build()
-    assert state == {"coverage": 95.0}
+    assert state == {"coverage": 1.0}
 
 
 def test_state_builder_vector(tmp_path):
@@ -32,7 +32,7 @@ def test_state_builder_vector(tmp_path):
     metrics_file.write_text('{"b": 2, "a": 1}')
     provider = MetricsProvider(metrics_file)
     builder = StateBuilder(provider)
-    assert builder.vector() == [1.0, 2.0]
+    assert builder.vector() == [0.5, 1.0]
 
 
 def test_ppo_agent_training_step(tmp_path):

--- a/vision/ppo/state_builder.py
+++ b/vision/ppo/state_builder.py
@@ -1,24 +1,54 @@
 from __future__ import annotations
 
-from typing import Dict
+from typing import Dict, Optional
+
+from pathlib import Path
 
 from core.observability import MetricsProvider
 
 
 class StateBuilder:
-    """Generate a numerical state representation from observability data."""
+    """Generate a normalized numerical state from metrics and logs."""
 
-    def __init__(self, metrics_provider: MetricsProvider) -> None:
+    def __init__(
+        self, metrics_provider: MetricsProvider, logs_path: Optional[Path] = None
+    ) -> None:
         self.metrics_provider = metrics_provider
+        self.logs_path = Path(logs_path) if logs_path else None
+
+    # --------------------------------------------------------------
+    def _log_metrics(self) -> Dict[str, float]:
+        if not self.logs_path:
+            return {}
+        path = self.logs_path
+        text = ""
+        if path.is_dir():
+            for p in path.glob("*.log"):
+                try:
+                    text += p.read_text(errors="ignore") + "\n"
+                except Exception:
+                    continue
+        elif path.exists():
+            try:
+                text = path.read_text(errors="ignore")
+            except Exception:
+                text = ""
+        lines = text.splitlines()
+        err = sum(1 for line in lines if "error" in line.lower())
+        return {"log_lines": float(len(lines)), "error_lines": float(err)}
 
     def build(self) -> Dict[str, float]:
         metrics = self.metrics_provider.collect()
-
-        return {
+        numeric = {
             k: float(v)
             for k, v in metrics.items()
             if isinstance(v, (int, float))
         }
+        numeric.update(self._log_metrics())
+        if numeric:
+            max_abs = max(abs(v) for v in numeric.values()) or 1.0
+            numeric = {k: v / max_abs for k, v in numeric.items()}
+        return numeric
 
     def vector(self) -> list[float]:
         """Return a sorted list of numeric metric values."""


### PR DESCRIPTION
## Summary
- support log aggregation in the PPO StateBuilder
- normalize collected metrics
- pass normalized state to RL training loop
- verify RL trainer and PPO StateBuilder behavior in tests

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc2cbb2a0832ab33bd0e6e82b0db3