### PR TITLE
Implement action ranking using fine-tuned LLM

### DIFF
--- a/reflector/rl/gen_actions.py
+++ b/reflector/rl/gen_actions.py
@@ -27,3 +27,15 @@ class ActionGenerator:
             context, max_tokens=max_tokens, num_return_sequences=num_actions
         )
 
+    # ------------------------------------------------------------------
+    @staticmethod
+    def filter_actions(actions: List[str], max_len: int = 200) -> List[str]:
+        """Return actions shorter than ``max_len`` characters."""
+        return [a for a in actions if len(a) <= max_len]
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def rank_actions(actions: List[str]) -> List[str]:
+        """Return ``actions`` ordered by length ascending."""
+        return sorted(actions, key=len)
+

--- a/reflector/rl/ppo_agent.py
+++ b/reflector/rl/ppo_agent.py
@@ -96,8 +96,19 @@ class PPOAgent:
     def train(self, metrics: Dict[str, float]) -> None:
         self.train_step(metrics)
 
-    def propose_patch(self, context: str, max_tokens: int = 64) -> str:
+    def propose_patch(
+        self,
+        context: str,
+        max_tokens: int = 64,
+        num_actions: int = 3,
+        max_len: int = 200,
+    ) -> str:
+        """Return best ranked patch proposal for ``context``."""
         if not self.action_gen:
             return ""
-        patches = self.action_gen.propose(context, max_tokens=max_tokens)
+        patches = self.action_gen.propose(
+            context, max_tokens=max_tokens, num_actions=num_actions
+        )
+        patches = self.action_gen.filter_actions(patches, max_len=max_len)
+        patches = self.action_gen.rank_actions(patches)
         return patches[0] if patches else ""

--- a/tests/test_gen_actions.py
+++ b/tests/test_gen_actions.py
@@ -9,10 +9,25 @@ class DummyPipe:
         return [{"generated_text": "patch"} for _ in range(num_return_sequences)]
 
 
+class VarPipe:
+    def __call__(self, prompt, max_new_tokens=64, num_return_sequences=1):
+        return [
+            {"generated_text": "x" * (i + 1)} for i in range(num_return_sequences)
+        ]
+
+
 def test_action_generator_produces_patch():
     ag = ActionGenerator(llm=CodeLLM(pipeline=DummyPipe()))
     patches = ag.propose("context")
     assert patches == ["patch"]
+
+
+def test_filter_and_rank_actions():
+    ag = ActionGenerator(llm=CodeLLM(pipeline=VarPipe()))
+    patches = ag.propose("ctx", num_actions=3)
+    filtered = ag.filter_actions(patches, max_len=2)
+    ranked = ag.rank_actions(filtered)
+    assert ranked == ["x", "xx"]
 
 
 def test_ppo_agent_proposes_patch(tmp_path):
@@ -25,3 +40,15 @@ def test_ppo_agent_proposes_patch(tmp_path):
     agent = PPOAgent(replay_buffer=buf, state_builder=builder, action_gen=ag)
     patch = agent.propose_patch("def foo(): pass")
     assert patch == "patch"
+
+
+def test_ppo_agent_uses_ranked_patch(tmp_path):
+    metrics_file = tmp_path / "m.json"
+    metrics_file.write_text('{"cpu": 0}')
+    provider = MetricsProvider(metrics_file)
+    builder = StateBuilder(provider)
+    buf = ReplayBuffer(capacity=1)
+    ag = ActionGenerator(llm=CodeLLM(pipeline=VarPipe()))
+    agent = PPOAgent(replay_buffer=buf, state_builder=builder, action_gen=ag)
+    patch = agent.propose_patch("ctx", num_actions=3, max_len=2)
+    assert patch == "x"


### PR DESCRIPTION
## Summary
- filter and rank code patches generated from the fine-tuned code LLM
- pick the best ranked patch in the PPO agent
- add unit tests for ranking behaviour

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc6ddc2fc832a9b6bf044f6a86e58