### PR TITLE
Implement configurable reward weights

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -28,3 +28,8 @@ logging:
   config_file: logging.conf
   level: INFO
   logfile: null
+
+reward:
+  correctness: 1.0
+  performance: 0.5
+  style: 0.2

--- a/core/config.py
+++ b/core/config.py
@@ -43,6 +43,11 @@ DEFAULT_CONFIG = {
         "level": "INFO",
         "logfile": None,
     },
+    "reward": {
+        "correctness": 1.0,
+        "performance": 0.5,
+        "style": 0.2,
+    },
 }
 
 CONFIG_PATH = Path(__file__).resolve().parents[1] / "config.yaml"
@@ -64,6 +69,7 @@ def load_config(path: str | Path | None = None) -> dict:
         "planner": {**DEFAULT_CONFIG["planner"], **data.get("planner", {})},
         "tracing": {**DEFAULT_CONFIG["tracing"], **data.get("tracing", {})},
         "logging": {**DEFAULT_CONFIG["logging"], **data.get("logging", {})},
+        "reward": {**DEFAULT_CONFIG["reward"], **data.get("reward", {})},
     }
 
     if "DB_PATH" in os.environ:
@@ -131,6 +137,13 @@ def load_config(path: str | Path | None = None) -> dict:
         cfg["logging"]["level"] = os.environ["LOG_LEVEL"]
     if "LOG_FILE" in os.environ:
         cfg["logging"]["logfile"] = os.environ["LOG_FILE"]
+
+    if "REWARD_CORRECTNESS" in os.environ:
+        cfg["reward"]["correctness"] = float(os.environ["REWARD_CORRECTNESS"])
+    if "REWARD_PERFORMANCE" in os.environ:
+        cfg["reward"]["performance"] = float(os.environ["REWARD_PERFORMANCE"])
+    if "REWARD_STYLE" in os.environ:
+        cfg["reward"]["style"] = float(os.environ["REWARD_STYLE"])
 
     return cfg
 

--- a/reflector/rl/reward.py
+++ b/reflector/rl/reward.py
@@ -4,12 +4,28 @@ from __future__ import annotations
 
 from typing import Dict, Tuple
 
+from core.config import load_config
+
 # Default weights for each reward component
 DEFAULT_WEIGHTS = {
     "correctness": 1.0,
     "performance": 0.5,
     "style": 0.2,
 }
+
+
+def get_weights() -> Dict[str, float]:
+    """Return reward weights from configuration or defaults."""
+    cfg = load_config()
+    conf = cfg.get("reward", {}) if isinstance(cfg, dict) else {}
+    weights = DEFAULT_WEIGHTS.copy()
+    for key in list(weights):
+        if key in conf:
+            try:
+                weights[key] = float(conf[key])
+            except Exception:
+                pass
+    return weights
 
 
 def reward_terms(metrics: Dict[str, float]) -> Dict[str, float]:
@@ -62,8 +78,8 @@ def calculate_reward(
 ) -> Tuple[float, Dict[str, float]]:
     """Return weighted reward and component terms."""
     terms = reward_terms(metrics)
-    w = weights or DEFAULT_WEIGHTS
+    w = weights or get_weights()
     reward = sum(w.get(k, 0.0) * v for k, v in terms.items())
     return reward, terms
 
-__all__ = ["reward_terms", "calculate_reward", "DEFAULT_WEIGHTS"]
+__all__ = ["reward_terms", "calculate_reward", "DEFAULT_WEIGHTS", "get_weights"]

--- a/tests/test_rl_reward.py
+++ b/tests/test_rl_reward.py
@@ -13,3 +13,12 @@ def test_weighted_reward():
     metrics = {"success": 1, "runtime": 1, "style_score": 1}
     reward, _ = calculate_reward(metrics, weights={"correctness": 1, "performance": 1, "style": 1})
     assert reward == 1 - 1 + 1
+
+
+def test_configured_weights(tmp_path, monkeypatch):
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("""reward:\n  correctness: 2\n  performance: 0.1\n  style: 0\n""")
+    monkeypatch.setenv("CONFIG_FILE", str(cfg))
+    metrics = {"success": 1, "runtime": 2, "style_score": 1}
+    reward, _ = calculate_reward(metrics)
+    assert reward == 2 * 1 + 0.1 * -2 + 0


### PR DESCRIPTION
## Summary
- add reward weight section to repo config
- support env overrides for reward weights
- load reward weights from config in RL helpers
- test config-driven reward calculation

## Testing
- `pytest tests/test_rl_reward.py tests/test_reward.py --maxfail=1 --disable-warnings -q`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ImportError while loading conftest '/workspace/AI-SWA/tests/conftest.py'. ModuleNotFoundError: No module named 'google')*


------
https://chatgpt.com/codex/tasks/task_e_686fccc1cc18832abf7733b45bc116aa