### PR TITLE
Define gene hyperparams and add serialization

### DIFF
--- a/docs/architecture/two_speed_reflector.md
+++ b/docs/architecture/two_speed_reflector.md
@@ -18,3 +18,19 @@ The Reflector core employs a two-speed learning approach. A fast PPO based inner
 3. **State Rollback** – `SimulationEnvironment.evaluate()` now snapshots simulator state before evaluating each candidate gene and restores it afterwards so every candidate starts from identical conditions.
 
 This coordination ensures consistent evaluation and simplifies integrating additional background tasks in future revisions.
+
+## Gene Structure
+
+Each outer-loop iteration manipulates a **gene** representing key PPO hyperparameters:
+
+- `architecture` – tuple of hidden layer sizes for the policy network.
+- `learning_rate` – shared learning rate for actor and critic updates.
+- `clip_epsilon` – clipping range for PPO updates.
+- `gamma` – discount factor applied to rewards.
+
+### Introducing New Gene Configurations
+
+`EvolutionaryPolicyOptimizer` generates new candidates by calling
+`Gene.mutate()` and `Gene.crossover()`. After evaluation the winning gene can
+be persisted with `Gene.to_json()` and reloaded via `Gene.from_json()` on the
+next run, allowing evolution to resume from the most successful configuration.

--- a/reflector/rl/evolution.py
+++ b/reflector/rl/evolution.py
@@ -58,6 +58,28 @@ class HyperParams:
             "sample_strategy": self.sample_strategy,
         }
 
+    def to_json(self, path: Path) -> None:
+        """Serialize parameters to ``path`` as JSON."""
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(self.to_dict(), f)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> HyperParams:
+        return cls(
+            buffer_capacity=data["buffer_capacity"],
+            sample_strategy=data.get("sample_strategy", "uniform"),
+            actor_lr=data["actor_lr"],
+            critic_lr=data["critic_lr"],
+            gamma=data["gamma"],
+            clip_epsilon=data["clip_epsilon"],
+        )
+
+    @classmethod
+    def from_json(cls, path: Path) -> HyperParams:
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return cls.from_dict(data)
+
 
 @dataclass
 class EvolutionEnvironment:

--- a/tests/test_hyperparams_serialization.py
+++ b/tests/test_hyperparams_serialization.py
@@ -1,0 +1,27 @@
+from reflector.rl.evolution import HyperParams
+
+
+def test_hyperparams_json_roundtrip(tmp_path):
+    params = HyperParams(
+        buffer_capacity=4,
+        actor_lr=0.001,
+        critic_lr=0.002,
+        gamma=0.95,
+        clip_epsilon=0.3,
+        sample_strategy="fifo",
+    )
+    path = tmp_path / "params.json"
+    params.to_json(path)
+    loaded = HyperParams.from_json(path)
+    assert params == loaded
+
+
+def test_hyperparams_mutation_ranges():
+    params = HyperParams()
+    mutated = params.mutate()
+    assert mutated.buffer_capacity >= 2
+    assert mutated.actor_lr >= 1e-5
+    assert mutated.critic_lr >= 1e-5
+    assert 0.5 <= mutated.gamma <= 0.999
+    assert 0.05 <= mutated.clip_epsilon <= 1.0
+    assert mutated.sample_strategy == params.sample_strategy

--- a/vision/epo/gene.py
+++ b/vision/epo/gene.py
@@ -9,7 +9,11 @@ from typing import Tuple
 
 @dataclass
 class Gene:
-    """Hyperparameters and architecture for a PPO agent."""
+    """Set of PPO hyperparameters evolved by the outer loop.
+
+    A gene encodes the architecture of the policy network along with key
+    training parameters that influence learning dynamics.
+    """
 
     architecture: Tuple[int, ...] = (64,)
     learning_rate: float = 0.001


### PR DESCRIPTION
## Summary
- document gene hyperparameters in the two-speed architecture doc
- clarify gene description in code
- add JSON round-trip helpers for `HyperParams`
- test `HyperParams` serialization and mutation

## Testing
- `pytest -k 'not integration' --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68703eaa7f78832ab24895238f04229e