### PR TITLE
Add auth enforcement for broker and worker

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -15,6 +15,8 @@ security:
   api_tokens_env: API_TOKENS
   plugin_signing_key: null
   plugin_signing_key_env: PLUGIN_SIGNING_KEY
+  worker_token: null
+  worker_token_env: WORKER_TOKEN
 sandbox:
   root: sandbox
   allowed_commands:

--- a/core/config.py
+++ b/core/config.py
@@ -23,6 +23,8 @@ DEFAULT_CONFIG = {
         "plugin_signing_key_env": "PLUGIN_SIGNING_KEY",
         "plugin_policy_file": "plugins/policy.json",
         "plugin_policy_file_env": "PLUGIN_POLICY_FILE",
+        "worker_token": None,
+        "worker_token_env": "WORKER_TOKEN",
     },
     "sandbox": {
         "root": "sandbox",
@@ -105,6 +107,8 @@ def load_config(path: str | Path | None = None) -> dict:
         sec["plugin_signing_key"] = os.environ["PLUGIN_SIGNING_KEY"]
     if "PLUGIN_POLICY_FILE" in os.environ:
         sec["plugin_policy_file"] = os.environ["PLUGIN_POLICY_FILE"]
+    if "WORKER_TOKEN" in os.environ:
+        sec["worker_token"] = os.environ["WORKER_TOKEN"]
 
     env_name = sec.get("api_key_env")
     if env_name and env_name in os.environ:
@@ -115,6 +119,9 @@ def load_config(path: str | Path | None = None) -> dict:
     env_name = sec.get("plugin_signing_key_env")
     if env_name and env_name in os.environ:
         sec["plugin_signing_key"] = os.environ[env_name]
+    env_name = sec.get("worker_token_env")
+    if env_name and env_name in os.environ:
+        sec["worker_token"] = os.environ[env_name]
     env_name = sec.get("plugin_policy_file_env")
     if env_name and env_name in os.environ:
         sec["plugin_policy_file"] = os.environ[env_name]

--- a/core/security.py
+++ b/core/security.py
@@ -41,8 +41,7 @@ def verify_token(authorization: str | None = Header(None)) -> User:
     """Validate ``Authorization`` header and return the requesting user."""
     tokens = _parse_tokens()
     if not tokens:
-        # No tokens configured -> allow anonymous access for tests
-        return User(username="anonymous", role="admin")
+        raise HTTPException(status_code=401, detail="Token authentication required")
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="Missing or invalid token")
     token = authorization.split(" ", 1)[1]

--- a/tests/integration/test_autoscaler.py
+++ b/tests/integration/test_autoscaler.py
@@ -13,6 +13,8 @@ def start_broker(tmp_path: Path, port: int, metrics_port: int):
     env = os.environ.copy()
     env["DB_PATH"] = str(tmp_path / "api.db")
     env["BROKER_METRICS_PORT"] = str(metrics_port)
+    env["API_TOKENS"] = "admintoken:admin:admin,workertoken:worker:worker"
+    env["WORKER_TOKEN"] = "workertoken"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     proc = subprocess.Popen(
         [
@@ -45,6 +47,7 @@ def run_autoscaler(base_url: str, metrics_port: int):
     env["AUTOSCALER_LOOPS"] = "5"
     env["AUTOSCALER_INTERVAL"] = "0.5"
     env["WORKER_METRICS_PORT"] = "0"
+    env["WORKER_TOKEN"] = "workertoken"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     result = subprocess.run(
         [sys.executable, "-m", "worker.autoscaler"],
@@ -81,6 +84,7 @@ def test_autoscaler_processes_queue(tmp_path):
                 f"{base}/tasks",
                 json={"description": "demo", "command": "echo hi"},
                 timeout=5,
+                headers={"Authorization": "Bearer admintoken"},
             )
         assert queue_length(metrics_port) == 2
         run_autoscaler(base, metrics_port)

--- a/tests/test_broker_api.py
+++ b/tests/test_broker_api.py
@@ -213,6 +213,8 @@ def test_broker_container(tmp_path):
             "8001:8000",
             "-e",
             f"DB_PATH={tmp_path/'api.db'}",
+            "-e",
+            "API_TOKENS=admintoken:admin:admin",
             image,
         ],
         stdout=subprocess.PIPE,
@@ -228,9 +230,16 @@ def test_broker_container(tmp_path):
             except requests.RequestException:
                 time.sleep(0.5)
 
-        resp = requests.post("http://localhost:8001/tasks", json={"description": "demo"})
+        resp = requests.post(
+            "http://localhost:8001/tasks",
+            json={"description": "demo"},
+            headers={"Authorization": "Bearer admintoken"},
+        )
         assert resp.status_code == 200
-        resp = requests.get("http://localhost:8001/tasks")
+        resp = requests.get(
+            "http://localhost:8001/tasks",
+            headers={"Authorization": "Bearer admintoken"},
+        )
         assert any(t["description"] == "demo" for t in resp.json())
     finally:
         proc.terminate()

--- a/tests/test_orchestrator_api.py
+++ b/tests/test_orchestrator_api.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 
 def setup_module(module):
     os.environ["METRICS_PORT"] = "0"
+    os.environ["API_KEY"] = "secret"
+    os.environ["API_TOKENS"] = "admintoken:admin:admin"
     global api
     import services.orchestrator_api as api_mod
     api = reload(api_mod)
@@ -16,17 +18,20 @@ def teardown_module(module):
     if api._proc and api._proc.poll() is None:
         api._proc.terminate()
         api._proc.wait(timeout=5)
+    os.environ.pop("API_KEY")
+    os.environ.pop("API_TOKENS")
 
 
 def test_start_stop_status():
     client = TestClient(api.app)
+    headers = {"X-API-Key": "secret", "Authorization": "Bearer admintoken"}
 
     # initially not running
-    resp = client.get("/status")
+    resp = client.get("/status", headers=headers)
     assert resp.status_code == 200
     assert resp.json()["running"] is False
 
-    resp = client.post("/start")
+    resp = client.post("/start", headers=headers)
     assert resp.status_code == 200
     pid = resp.json()["pid"]
     assert isinstance(pid, int)
@@ -34,11 +39,11 @@ def test_start_stop_status():
     # give process a moment
     time.sleep(0.2)
 
-    resp = client.get("/status")
+    resp = client.get("/status", headers=headers)
     assert resp.json()["running"] is True
 
-    resp = client.post("/stop")
+    resp = client.post("/stop", headers=headers)
     assert resp.status_code == 200
 
-    resp = client.get("/status")
+    resp = client.get("/status", headers=headers)
     assert resp.json()["running"] is False

--- a/tests/test_worker_async_loop.py
+++ b/tests/test_worker_async_loop.py
@@ -13,6 +13,8 @@ def start_broker(tmp_path, port=8003, metrics_port=0):
     env = os.environ.copy()
     env["DB_PATH"] = str(tmp_path / "api.db")
     env["BROKER_METRICS_PORT"] = str(metrics_port)
+    env["API_TOKENS"] = "admintoken:admin:admin,workertoken:worker:worker"
+    env["WORKER_TOKEN"] = "workertoken"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     proc = subprocess.Popen(
         [
@@ -43,6 +45,7 @@ def run_worker(base_url, concurrency):
     env["BROKER_URL"] = base_url
     env["WORKER_METRICS_PORT"] = "0"
     env["WORKER_CONCURRENCY"] = str(concurrency)
+    env["WORKER_TOKEN"] = "workertoken"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     return subprocess.run(
         [sys.executable, "-m", "worker.main"],
@@ -73,6 +76,7 @@ def test_tasks_run_in_parallel(tmp_path):
                 f"{base_url}/tasks",
                 json={"description": "sleep", "command": cmd},
                 timeout=5,
+                headers={"Authorization": "Bearer admintoken"},
             )
             ids.append(resp.json()["id"])
 

--- a/tests/test_worker_broker_flow.py
+++ b/tests/test_worker_broker_flow.py
@@ -12,6 +12,8 @@ def start_broker(tmp_path, port=8001):
     env = os.environ.copy()
     env["DB_PATH"] = str(tmp_path / "api.db")
     env["METRICS_PORT"] = "0"
+    env["API_TOKENS"] = "admintoken:admin:admin,workertoken:worker:worker"
+    env["WORKER_TOKEN"] = "workertoken"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     proc = subprocess.Popen(
         [
@@ -41,6 +43,7 @@ def run_worker(base_url):
     env = os.environ.copy()
     env["BROKER_URL"] = base_url
     env["METRICS_PORT"] = "0"
+    env["WORKER_TOKEN"] = "workertoken"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     result = subprocess.run(
         [sys.executable, "-m", "worker.main"],
@@ -76,6 +79,7 @@ def test_worker_success_result(tmp_path):
             f"{base_url}/tasks",
             json={"description": "demo", "command": "echo hi"},
             timeout=5,
+            headers={"Authorization": "Bearer admintoken"},
         )
         task_id = resp.json()["id"]
         result = run_worker(base_url)
@@ -99,6 +103,7 @@ def test_worker_failure_result(tmp_path):
             f"{base_url}/tasks",
             json={"description": "fail", "command": cmd},
             timeout=5,
+            headers={"Authorization": "Bearer admintoken"},
         )
         task_id = resp.json()["id"]
         result = run_worker(base_url)

--- a/tests/test_worker_concurrency.py
+++ b/tests/test_worker_concurrency.py
@@ -13,6 +13,8 @@ def start_broker(tmp_path, port=8002, metrics_port=0):
     env = os.environ.copy()
     env["DB_PATH"] = str(tmp_path / "api.db")
     env["BROKER_METRICS_PORT"] = str(metrics_port)
+    env["API_TOKENS"] = "admintoken:admin:admin,workertoken:worker:worker"
+    env["WORKER_TOKEN"] = "workertoken"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     proc = subprocess.Popen(
         [
@@ -42,6 +44,7 @@ def run_worker_async(base_url: str, metrics_port: int):
     env = os.environ.copy()
     env["BROKER_URL"] = base_url
     env["WORKER_METRICS_PORT"] = str(metrics_port)
+    env["WORKER_TOKEN"] = "workertoken"
     env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
     return subprocess.Popen(
         [sys.executable, "-m", "worker.main"],
@@ -79,6 +82,7 @@ def test_multiple_workers_process_tasks_once(tmp_path):
                 f"{base_url}/tasks",
                 json={"description": f"t{i}", "command": f"echo {i}"},
                 timeout=5,
+                headers={"Authorization": "Bearer admintoken"},
             )
             task_ids.append(r.json()["id"])
 

--- a/worker/main.py
+++ b/worker/main.py
@@ -42,7 +42,12 @@ logger = logging.getLogger(__name__)
 def fetch_next_task():
     """Return the next task from the broker or ``None`` if the queue is empty."""
     api_key = config["security"]["api_key"]
-    headers = {"X-API-Key": api_key} if api_key else {}
+    token = config["security"].get("worker_token")
+    headers = {}
+    if api_key:
+        headers["X-API-Key"] = api_key
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     resp = requests.get(f"{BROKER_URL}/tasks/next", headers=headers)
     resp.raise_for_status()
     return resp.json()
@@ -56,7 +61,12 @@ async def process_task(runner: AsyncRunner, task: dict, sem: asyncio.Semaphore):
         result = await runner.run(command)
     logger.info("Executed command for task %s", task["id"])
     api_key = config["security"]["api_key"]
-    headers = {"X-API-Key": api_key} if api_key else {}
+    token = config["security"].get("worker_token")
+    headers = {}
+    if api_key:
+        headers["X-API-Key"] = api_key
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     requests.post(
         f"{BROKER_URL}/tasks/{task['id']}/result",
         json={


### PR DESCRIPTION
## Summary
- enforce bearer-token auth by default
- configure `worker_token` option in config
- require auth for orchestrator API tests
- update worker to send bearer credentials
- adjust tests accordingly

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68704ef82d38832a958fa5f7c4a90abf