### PR TITLE
Add plugin sandbox executor with policy checks

### DIFF
--- a/docs/plugins/security_model.md
+++ b/docs/plugins/security_model.md
@@ -1,0 +1,15 @@
+# Plugin Security Model
+
+Plugins execute third-party code and therefore run inside a strict sandbox. Each
+plugin directory contains a `manifest.json` describing required permissions. The
+host validates this manifest against `plugins/manifest_schema.json` and applies a
+policy file if configured via `PLUGIN_POLICY_FILE`.
+
+The `plugins.executor.run_plugin()` helper copies plugin code into the sandbox
+root, verifies the manifest and policy, then runs `plugin.py` with `python -I`
+inside that directory using `ToolRunner`. Only the `python` command is allowed.
+This prevents access to arbitrary binaries or paths outside the sandbox.
+
+If the policy file does not permit a plugin ID or its permissions, execution
+fails before any code is run. When `PLUGIN_SIGNING_KEY` is set, manifests must
+also include a valid signature.

--- a/plugins/executor.py
+++ b/plugins/executor.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+from core.config import load_config
+from core.tool_runner import ToolRunner
+from core.plugins import load_manifest
+
+
+def run_plugin(plugin_dir: str | Path) -> subprocess.CompletedProcess:
+    """Execute a plugin's ``plugin.py`` inside the sandbox.
+
+    The plugin manifest is validated and checked against the policy before
+    execution. The plugin code is copied into the sandbox root and executed
+    with ``python -I`` to avoid environment side effects.
+    """
+    plugin_path = Path(plugin_dir).resolve()
+    manifest = load_manifest(plugin_path / "manifest.json")
+
+    cfg = load_config()
+    sandbox_root = Path(cfg["sandbox"].get("root", "sandbox"))
+    sandbox_root.mkdir(parents=True, exist_ok=True)
+
+    dest = sandbox_root / manifest.id
+    if dest.exists():
+        shutil.rmtree(dest)
+    shutil.copytree(plugin_path, dest)
+
+    runner = ToolRunner(dest, ["python"])
+    return runner.run("python -I plugin.py")

--- a/tests/test_plugin_executor.py
+++ b/tests/test_plugin_executor.py
@@ -1,0 +1,36 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from plugins.executor import run_plugin
+
+
+def _create_plugin(tmp_path: Path, pid: str, perms: list[str]) -> Path:
+    pdir = tmp_path / pid
+    pdir.mkdir()
+    (pdir / "plugin.py").write_text("print('ok')")
+    manifest = {
+        "id": pid,
+        "name": pid,
+        "version": "0.1",
+        "permissions": perms,
+    }
+    (pdir / "manifest.json").write_text(json.dumps(manifest))
+    return pdir
+
+
+def test_run_plugin(tmp_path, monkeypatch):
+    monkeypatch.setenv("PLUGIN_POLICY_FILE", str(tmp_path / "policy.json"))
+    (tmp_path / "policy.json").write_text(json.dumps({"plugins": {"demo": {"permissions": ["read_files"]}}}))
+    plugin_dir = _create_plugin(tmp_path, "demo", ["read_files"])
+    result = run_plugin(plugin_dir)
+    assert result.stdout.strip() == "ok"
+
+
+def test_run_plugin_disallowed(tmp_path, monkeypatch):
+    monkeypatch.setenv("PLUGIN_POLICY_FILE", str(tmp_path / "policy.json"))
+    (tmp_path / "policy.json").write_text(json.dumps({"plugins": {}}))
+    plugin_dir = _create_plugin(tmp_path, "demo", ["read_files"])
+    with pytest.raises(ValueError):
+        run_plugin(plugin_dir)


### PR DESCRIPTION
## Summary
- create `plugins.executor.run_plugin` to run plugins inside ToolRunner sandbox
- document plugin security model
- test new sandbox executor

## Testing
- `pytest tests/test_plugin_executor.py -q`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68706288e1ac832aa86f8416ce0edee8