### PR TITLE
Implement WSJF baseline and RL hyper-heuristic

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -1134,7 +1134,7 @@
     - The Vision Engine produces a transparent, defensible ranking using WSJF scores.
     - The RL agent's suggested prioritizations are logged for offline evaluation.
   priority: 1
-  status: pending
+  status: done
   epic: Vision Engine & Prioritization
 
 - id: 151

--- a/tests/test_rl_vs_wsjf_integration.py
+++ b/tests/test_rl_vs_wsjf_integration.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 
 from core.task import Task
-from vision.vision_engine import VisionEngine, RLAgent, wsjf_score
+from vision.vision_engine import VisionEngine, RLAgent
+from vision.wsjf import wsjf_score
 
 
 def _task(id, ubv, tc, rr, size):

--- a/tests/vision/test_hyper_heuristic.py
+++ b/tests/vision/test_hyper_heuristic.py
@@ -1,0 +1,45 @@
+import unittest
+from pathlib import Path
+import json
+
+from core.task import Task
+from vision import VisionEngine, RLHyperHeuristicAgent
+
+
+class TestHyperHeuristicAgent(unittest.TestCase):
+    def _task(self, id, ubv, tc, rr, size):
+        t = Task(
+            id=id,
+            description="",
+            component="vision",
+            dependencies=[],
+            priority=1,
+            status="pending",
+        )
+        t.user_business_value = ubv
+        t.time_criticality = tc
+        t.risk_reduction = rr
+        t.job_size = size
+        return t
+
+    def test_suggest_orders_by_wsjf(self):
+        agent = RLHyperHeuristicAgent(exploration=0)
+        t1 = self._task(1, 10, 2, 1, 5)  # 2.6
+        t2 = self._task(2, 5, 1, 1, 2)   # 3.5
+        t3 = self._task(3, 8, 0, 0, 4)   # 2.0
+        ordered = agent.suggest([t1, t2, t3])
+        self.assertEqual([t.id for t in ordered], [2, 1, 3])
+
+    def test_shadow_mode_logs_history(self):
+        log_file = Path("history.log")
+        agent = RLHyperHeuristicAgent(history_path=log_file, exploration=0)
+        ve = VisionEngine(rl_agent=agent, shadow_mode=True)
+        t1 = self._task(1, 1, 1, 1, 1)
+        t2 = self._task(2, 1, 1, 1, 2)
+        ve.prioritize([t1, t2])
+        self.assertEqual(len(agent.history), 1)
+        self.assertTrue(log_file.exists())
+        data = json.loads(log_file.read_text().strip())
+        self.assertIn("baseline", data)
+        log_file.unlink()
+

--- a/vision/__init__.py
+++ b/vision/__init__.py
@@ -1,6 +1,8 @@
 """Vision Engine package."""
 
-from .vision_engine import VisionEngine, RLAgent, wsjf_score
+from .vision_engine import VisionEngine, RLAgent
+from .hyper_heuristic import RLHyperHeuristicAgent
+from .wsjf import wsjf_score
 from .training import RLTrainer, TwoSpeedTrainer
 from .ppo import ReplayBuffer, EWC, StateBuilder, PPOAgent
 from .epo import (
@@ -15,6 +17,7 @@ __all__ = [
     "VisionEngine",
     "RLAgent",
     "wsjf_score",
+    "RLHyperHeuristicAgent",
     "RLTrainer",
     "TwoSpeedTrainer",
     "ReplayBuffer",

--- a/vision/hyper_heuristic.py
+++ b/vision/hyper_heuristic.py
@@ -1,0 +1,50 @@
+"""Reinforcement Learning Hyper-Heuristic agent for task prioritization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+import random
+from pathlib import Path
+
+from core.task import Task
+from core.code_llm import CodeLLM
+from .wsjf import wsjf_score
+from .vision_engine import RLAgent
+
+
+@dataclass
+class RLHyperHeuristicAgent(RLAgent):
+    """Simple RL-based hyper-heuristic adjusting WSJF weighting."""
+
+    heuristic_weights: Dict[str, float] = field(default_factory=lambda: {"wsjf": 1.0})
+    exploration: float = 0.05
+
+    def __init__(
+        self,
+        history_path: Optional[Path] = None,
+        training_path: Optional[Path] = None,
+        code_model: Optional[CodeLLM] = None,
+        heuristic_weights: Optional[Dict[str, float]] = None,
+        exploration: float = 0.05,
+    ) -> None:
+        super().__init__(history_path=history_path, training_path=training_path, code_model=code_model)
+        self.heuristic_weights = heuristic_weights or {"wsjf": 1.0}
+        self.exploration = exploration
+
+    def suggest(self, tasks: List[Task]) -> List[Task]:
+        """Return tasks ordered by weighted WSJF score with optional noise."""
+        scored = []
+        for t in tasks:
+            score = self.heuristic_weights["wsjf"] * wsjf_score(t)
+            score += random.random() * self.exploration
+            scored.append((score, t))
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [t for _, t in scored]
+
+    def train(self, metrics: Dict[str, float]) -> float:
+        """Adjust heuristic weight based on provided metrics and return reward."""
+        reward = super().train(metrics)
+        delta = metrics.get("gain", 0.0)
+        self.heuristic_weights["wsjf"] += 0.1 * delta
+        return reward

--- a/vision/vision_engine.py
+++ b/vision/vision_engine.py
@@ -10,19 +10,7 @@ from reflector.rl.reward import calculate_reward
 from core.code_llm import CodeLLM
 
 from core.task import Task
-
-
-def wsjf_score(task: Task) -> float:
-    """Return Weighted Shortest Job First score for ``task``."""
-    cod = (
-        getattr(task, "user_business_value", 0)
-        + getattr(task, "time_criticality", 0)
-        + getattr(task, "risk_reduction", 0)
-    )
-    job_size = getattr(task, "job_size", 1)
-    if job_size == 0:
-        job_size = 1
-    return cod / job_size
+from .wsjf import wsjf_score
 
 
 @dataclass

--- a/vision/wsjf.py
+++ b/vision/wsjf.py
@@ -1,0 +1,21 @@
+"""Weighted Shortest Job First (WSJF) calculator."""
+
+from core.task import Task
+
+
+def wsjf_score(task: Task) -> float:
+    """Return the WSJF score for ``task``.
+
+    The score is computed as (user_business_value + time_criticality +
+    risk_reduction) / job_size. Missing metrics default to zero and a
+    job size of zero is treated as one.
+    """
+    cod = (
+        getattr(task, "user_business_value", 0)
+        + getattr(task, "time_criticality", 0)
+        + getattr(task, "risk_reduction", 0)
+    )
+    job_size = getattr(task, "job_size", 1)
+    if job_size == 0:
+        job_size = 1
+    return cod / job_size


### PR DESCRIPTION
## Summary
- implement a dedicated `wsjf` module
- add `RLHyperHeuristicAgent` for RL-based prioritization
- hook VisionEngine into the wsjf module
- expose the agent in the vision package
- mark the hybrid vision engine task complete
- test hyper-heuristic behaviour and update integration tests

## Testing
- `pytest --maxfail=1 --disable-warnings -q tests/vision/test_hyper_heuristic.py tests/test_rl_vs_wsjf_integration.py`


------
https://chatgpt.com/codex/tasks/task_e_6871cd02eb94832a825c9d70aa2bfaa1