### PR TITLE
Add OPG deployment scripts

### DIFF
--- a/deploy/setup_observability.sh
+++ b/deploy/setup_observability.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -euo pipefail
+SCRIPT_DIR="$(dirname "$0")"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Generate TLS certificates
+./observability/generate_certs.sh
+
+# Start observability services
+if command -v docker-compose >/dev/null 2>&1; then
+    docker-compose up -d otel-collector prometheus grafana
+else
+    echo "docker-compose not found" >&2
+    exit 1
+fi
+
+echo "Observability stack started"

--- a/deploy/validate_observability.sh
+++ b/deploy/validate_observability.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -euo pipefail
+SCRIPT_DIR="$(dirname "$0")"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Check Prometheus health
+curl -sk https://prometheus:9090/-/healthy > /dev/null
+
+# Check Grafana health
+curl -sk https://grafana:3000/api/health | grep -q 'database' > /dev/null
+
+# Check collector metrics endpoint
+curl -sk https://otel-collector:8888/metrics > /dev/null
+
+# Validate that Prometheus scraped metrics for each service
+for svc in broker worker orchestrator io-service; do
+    if ! curl -skG https://prometheus:9090/api/v1/query --data-urlencode "query=up{service_name=\"$svc\"}" | grep -q '"value"'; then
+        echo "Prometheus missing metrics for $svc" >&2
+        exit 1
+    fi
+done
+
+echo "Observability stack validated"

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -8,3 +8,11 @@ scrape_configs:
       insecure_skip_verify: true
     static_configs:
       - targets: ['otel-collector:8889']
+  - job_name: 'ai-swa-services'
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - 'broker:9000'
+          - 'worker:9001'
+          - 'orchestrator:8000'
+          - 'io-service:9100'


### PR DESCRIPTION
## Summary
- add scripts in deploy/ for setting up and validating the OPG stack
- enable Prometheus scraping of service metrics

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6871e75f6c6c832a9f83618ebe0f54f5