### PR TITLE
Add Creative Synthesizer generator

### DIFF
--- a/core/creative_synthesizer.py
+++ b/core/creative_synthesizer.py
@@ -1,0 +1,58 @@
+"""Generate small prototype modules from templates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+
+class CreativeSynthesizer:
+    """Create simple code modules from built-in templates."""
+
+    DEFAULT_TEMPLATES: Dict[str, str] = {
+        "module": "\n".join([
+            '"""New module."""',
+            "",
+            "def main() -> None:",
+            "    pass",
+            "",
+            "if __name__ == '__main__':", 
+            "    main()",
+        ]),
+        "cli": "\n".join([
+            '"""Command line interface."""',
+            "import argparse",
+            "",
+            "def build_parser() -> argparse.ArgumentParser:",
+            "    parser = argparse.ArgumentParser()",
+            "    return parser",
+            "",
+            "def main(argv=None) -> int:",
+            "    parser = build_parser()",
+            "    parser.parse_args(argv)",
+            "    return 0",
+            "",
+            "if __name__ == '__main__':", 
+            "    raise SystemExit(main())",
+        ]),
+    }
+
+    def __init__(self, templates: Dict[str, str] | None = None) -> None:
+        self.templates = {**self.DEFAULT_TEMPLATES, **(templates or {})}
+
+    # ------------------------------------------------------------------
+    def available_types(self) -> list[str]:
+        """Return list of template names."""
+        return sorted(self.templates)
+
+    # ------------------------------------------------------------------
+    def generate(self, name: str, module_type: str = "module", directory: str | Path = ".") -> Path:
+        """Create a new file ``name`` with the given template."""
+        if module_type not in self.templates:
+            raise ValueError(f"Unknown template: {module_type}")
+        target_dir = Path(directory)
+        target_dir.mkdir(parents=True, exist_ok=True)
+        path = target_dir / f"{name}.py"
+        path.write_text(self.templates[module_type])
+        return path
+

--- a/docs/development/creative_synthesizer.md
+++ b/docs/development/creative_synthesizer.md
@@ -1,0 +1,22 @@
+# Creative Synthesizer
+
+The Creative Synthesizer provides quick skeletons for new modules. It ships with
+simple templates and can be invoked from the command line.
+
+## Usage
+
+Generate a basic module inside `core/`:
+
+```bash
+python scripts/creative_synthesizer_cli.py module my_module --output core
+```
+
+Generate a CLI skeleton:
+
+```bash
+python scripts/creative_synthesizer_cli.py cli my_tool --output tools
+```
+
+The command prints the path to the generated file.
+
+

--- a/scripts/creative_synthesizer_cli.py
+++ b/scripts/creative_synthesizer_cli.py
@@ -1,0 +1,30 @@
+"""CLI for the Creative Synthesizer."""
+
+import argparse
+from pathlib import Path
+from core.creative_synthesizer import CreativeSynthesizer
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Generate prototype modules")
+    parser.add_argument("type", help="Template type")
+    parser.add_argument("name", help="Module name (without .py)")
+    parser.add_argument("--output", default=".", help="Output directory")
+    return parser
+
+
+def main(argv=None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    synth = CreativeSynthesizer()
+    try:
+        path = synth.generate(args.name, args.type, directory=args.output)
+    except ValueError as exc:
+        parser.error(str(exc))
+        return 1
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/test_creative_synthesizer.py
+++ b/tests/test_creative_synthesizer.py
@@ -1,0 +1,10 @@
+from core.creative_synthesizer import CreativeSynthesizer
+
+
+def test_generate_module(tmp_path):
+    synth = CreativeSynthesizer()
+    path = synth.generate("sample", directory=tmp_path)
+    assert path.exists()
+    text = path.read_text()
+    assert "def main" in text
+


### PR DESCRIPTION
## Summary
- implement `CreativeSynthesizer` to scaffold tiny modules
- expose a CLI to generate templates
- document synthesizer usage
- test synthesizer generation

## Testing
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68720605445c832a98db56aec18edd18