### PR TITLE
Add intent mapper component

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -342,6 +342,13 @@ The ``RLAgent`` tracks an ``authority`` value from ``0.0`` to ``1.0``. The
 ``VisionEngine`` applies the agent's ordering to the top fraction of tasks
 equal to this authority. The value only increases when observed
 
+### Intent Mapper
+Receives prioritized epics from the Vision Engine and breaks them into
+executable tasks. Each epic is decomposed into a sequence of tasks with
+explicit dependencies and a default priority. The mapper records the
+originating epic so downstream components can trace the lineage of each
+task. This keeps the backlog synchronized with higher-level goals.
+
 ### Production Simulation Environment
 The Reflector Core uses a **ProductionSimulator** to mirror the behavior of the
 live system. The simulator models key services, databases, and load balancers

--- a/core/intent_mapper.py
+++ b/core/intent_mapper.py
@@ -1,0 +1,55 @@
+"""Map Vision Engine goals to executable tasks."""
+
+from dataclasses import dataclass
+from typing import List
+
+from .task import Task
+
+
+@dataclass
+class Epic:
+    """Representation of a high-level goal from the Vision Engine."""
+
+    id: int
+    title: str
+    steps: List[str]
+
+
+class IntentMapper:
+    """Decompose epics into concrete tasks with dependencies."""
+
+    def __init__(self, default_priority: int = 1) -> None:
+        self.default_priority = default_priority
+
+    def decompose_epic(self, epic: Epic, start_id: int = 1) -> List[Task]:
+        """Return tasks for ``epic`` starting at ``start_id``.
+
+        Tasks are ordered sequentially so that each depends on the previous one.
+        """
+        tasks: List[Task] = []
+        prev_id = None
+        tid = start_id
+        for step in epic.steps:
+            tasks.append(
+                Task(
+                    id=tid,
+                    description=step,
+                    dependencies=[prev_id] if prev_id is not None else [],
+                    priority=self.default_priority,
+                    status="pending",
+                    epic=epic.title,
+                )
+            )
+            prev_id = tid
+            tid += 1
+        return tasks
+
+    def map_goals(self, epics: List[Epic], start_id: int = 1) -> List[Task]:
+        """Convert a list of epics into an aggregated task list."""
+        tasks: List[Task] = []
+        tid = start_id
+        for epic in epics:
+            epic_tasks = self.decompose_epic(epic, start_id=tid)
+            tasks.extend(epic_tasks)
+            tid += len(epic_tasks)
+        return tasks

--- a/tests/test_intent_mapper.py
+++ b/tests/test_intent_mapper.py
@@ -1,0 +1,30 @@
+import pytest
+from core.intent_mapper import IntentMapper, Epic
+
+
+def test_decompose_epic_creates_dependency_chain(task_factory):
+    epic = Epic(id=1, title="E1", steps=["step1", "step2", "step3"])
+    mapper = IntentMapper(default_priority=2)
+    tasks = mapper.decompose_epic(epic, start_id=10)
+    ids = [t.id for t in tasks]
+    assert ids == [10, 11, 12]
+    assert tasks[0].dependencies == []
+    assert tasks[1].dependencies == [10]
+    assert tasks[2].dependencies == [11]
+    for t in tasks:
+        assert t.epic == "E1"
+        assert t.priority == 2
+        assert t.status == "pending"
+
+
+def test_map_goals_multiple_epics_produces_unique_ids():
+    epic1 = Epic(id=1, title="E1", steps=["a", "b"])
+    epic2 = Epic(id=2, title="E2", steps=["c"])
+    mapper = IntentMapper()
+    tasks = mapper.map_goals([epic1, epic2], start_id=1)
+    ids = [t.id for t in tasks]
+    assert ids == [1, 2, 3]
+    assert tasks[1].dependencies == [1]
+    assert tasks[2].dependencies == []
+    assert tasks[0].epic == "E1"
+    assert tasks[2].epic == "E2"


### PR DESCRIPTION
## Summary
- implement `core.intent_mapper` to convert Vision Engine epics into tasks
- test epic decomposition and dependency mapping
- document the intent-mapping process in `ARCHITECTURE.md`

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: test_ewc_reduces_catastrophic_forgetting)*

------
https://chatgpt.com/codex/tasks/task_e_68720b1f12f0832abab566109b0e8c46