### PR TITLE
Add policy examples and directory support

### DIFF
--- a/docs/governance/policy_library.md
+++ b/docs/governance/policy_library.md
@@ -1,0 +1,12 @@
+# Policy Library Guidelines
+
+The `policies/` directory stores JSON files that define what actions agents are prohibited from executing. Each policy must conform to `policy_schema.json`.
+
+## Authoring Policies
+
+1. Create a new `.json` file under `policies/` or a nested folder such as `policies/examples/`.
+2. Include a `blocked_actions` array listing task or action IDs to disable.
+3. Validate the file against `policies/policy_schema.json` using `jsonschema` before committing.
+4. Keep names short and descriptive so administrators can easily enable or disable them.
+
+Policies placed in a directory are merged together at runtime by the `EthicalSentinel`. This allows a library of reusable policy modules. Remove actions from the list to re-enable them on the next run.

--- a/policies/examples/allow_all.json
+++ b/policies/examples/allow_all.json
@@ -1,0 +1,3 @@
+{
+  "blocked_actions": []
+}

--- a/policies/examples/block_dangerous.json
+++ b/policies/examples/block_dangerous.json
@@ -1,0 +1,3 @@
+{
+  "blocked_actions": ["delete_production_database", "exfiltrate_data"]
+}


### PR DESCRIPTION
## Summary
- allow EthicalSentinel to load all JSON policies from a directory
- document how to author policy files
- provide example policy files

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6872150f2144832aa1362644f8a5946a