### PR TITLE
Add Slack notifications to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,3 +143,19 @@ EOF
         with:
           name: signed-plugin
           path: dist/example-0.1.0.zip*
+      - name: Notify Slack success
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data '{"text":"CI succeeded for ${{ github.repository }} at ${{ github.sha }}"}' \
+            "$SLACK_WEBHOOK_URL"
+      - name: Notify Slack failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data '{"text":"CI failed for ${{ github.repository }} at ${{ github.sha }}"}' \
+            "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -23,3 +23,19 @@ jobs:
           GRAFANA_URL: ${{ secrets.GRAFANA_URL }}
           GRAFANA_API_KEY: ${{ secrets.GRAFANA_API_KEY }}
         run: python scripts/apply_dashboards.py
+      - name: Notify Slack success
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data '{"text":"Grafana workflow succeeded for ${{ github.repository }} at ${{ github.sha }}"}' \
+            "$SLACK_WEBHOOK_URL"
+      - name: Notify Slack failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data '{"text":"Grafana workflow failed for ${{ github.repository }} at ${{ github.sha }}"}' \
+            "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,3 +54,19 @@ jobs:
         with:
           tag_name: ${{ github.event.inputs.version }}
           files: ai-swa-${{ github.event.inputs.version }}.tar.gz
+      - name: Notify Slack success
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data '{"text":"Release workflow succeeded for ${{ github.repository }} at ${{ github.sha }}"}' \
+            "$SLACK_WEBHOOK_URL"
+      - name: Notify Slack failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          curl -X POST -H 'Content-type: application/json' \
+            --data '{"text":"Release workflow failed for ${{ github.repository }} at ${{ github.sha }}"}' \
+            "$SLACK_WEBHOOK_URL"

--- a/docs/ci/slack_notifications.md
+++ b/docs/ci/slack_notifications.md
@@ -1,0 +1,15 @@
+# Slack Notification Format
+
+The GitHub Actions workflows send a message to Slack when a job finishes.
+
+Set a repository secret named `SLACK_WEBHOOK_URL` containing an incoming webhook URL for your workspace. Each workflow posts one of the following JSON payloads:
+
+```json
+{"text": "CI succeeded for <owner>/<repo> at <sha>"}
+```
+
+```json
+{"text": "CI failed for <owner>/<repo> at <sha>"}
+```
+
+Replace `<owner>/<repo>` with the repository slug and `<sha>` with the commit hash. The same format applies to other workflows like release and Grafana dashboard deployment.


### PR DESCRIPTION
## Summary
- configure Slack webhook secret for CI
- send status notifications from all GitHub workflows
- document Slack notification JSON format

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68722702ed9c832a8d6dc3df9cd2a5e3