### PR TITLE
Add RL training dataset export tool

### DIFF
--- a/research/RL_training.md
+++ b/research/RL_training.md
@@ -1,0 +1,12 @@
+# RL Training Data Generation
+
+This guide describes how to produce state/action datasets for offline experiments.
+
+1. Ensure the repository dependencies are installed.
+2. Run the export script against a workload file:
+
+```bash
+python scripts/export_training_data.py data/rl_training/sample.jsonl --steps 500 --workload workload.json
+```
+
+Each line in the output JSONL file contains a normalized metrics state and the chosen action. Datasets are stored under `data/rl_training/`.

--- a/scripts/export_training_data.py
+++ b/scripts/export_training_data.py
@@ -1,0 +1,50 @@
+"""Export state/action pairs from simulation runs for offline RL training."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from simulator.code_env import CodeEnv, Service, Database, LoadBalancer
+from core.production_simulator import SimulationMetricsProvider
+from reflector.state_builder import StateBuilder
+from reflector.rl.ppo_agent import PPOAgent
+from reflector.rl.replay_buffer import ReplayBuffer
+
+
+def build_env(workload: Path) -> CodeEnv:
+    env = CodeEnv(workload_path=workload)
+    env.add_service(Service(name="api", capacity=1))
+    env.add_database(Database(name="db", max_connections=1))
+    env.add_load_balancer(LoadBalancer(name="lb", targets=[env.simulator.services["api"]]))
+    return env
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=Path, help="Destination JSONL file")
+    parser.add_argument("--steps", type=int, default=100, help="Simulation steps")
+    parser.add_argument("--workload", type=Path, default=Path("workload.json"))
+    args = parser.parse_args()
+
+    env = build_env(args.workload)
+    provider = SimulationMetricsProvider(env.simulator)
+    builder = StateBuilder(provider)
+    agent = PPOAgent(replay_buffer=ReplayBuffer(capacity=8), state_builder=builder)
+
+    dataset = []
+    for _ in range(args.steps):
+        state = builder.build()
+        action, _ = agent.select_action(state)
+        env.step({"scale_service": {"name": "api", "delta": action}})
+        dataset.append({"state": state, "action": action})
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as fh:
+        for row in dataset:
+            fh.write(json.dumps(row) + "\n")
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI tool
+    main()


### PR DESCRIPTION
## Summary
- add `export_training_data.py` for collecting state/action pairs
- document dataset generation process
- create `data/rl_training` directory for storage

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: test_ewc_reduces_catastrophic_forgetting)*

------
https://chatgpt.com/codex/tasks/task_e_6872348ecfb8832ababa506909557b0d