### PR TITLE
Add RL metrics export and dashboard

### DIFF
--- a/docs/observability/rl_metrics.md
+++ b/docs/observability/rl_metrics.md
@@ -1,0 +1,20 @@
+# RL Training Metrics
+
+SelfArchitectAI training jobs expose Prometheus metrics when started with a non-zero `metrics_port`.
+
+## Metrics
+
+- `rl_training_reward` – reward for the most recent episode
+- `rl_training_episode_length` – steps in the most recent episode
+- `rl_training_reward_summary` – summary of reward values
+- `rl_training_episode_length_summary` – summary of episode lengths
+- `rl_training_episodes_total` – counter of processed episodes
+
+## Dashboard Setup
+
+1. Install Prometheus and Grafana as described in `docs/observability.md`.
+2. Run a training job using `RLTrainer(metrics_port=<port>)` so the metrics endpoint is available.
+3. Execute `python scripts/update_dashboards.py` to generate `grafana/dashboards/rl_metrics.json`.
+4. Import this JSON file into Grafana and select your Prometheus data source.
+
+The dashboard displays average reward and episode length over time along with the total episode count.

--- a/grafana/dashboards/rl_metrics.json
+++ b/grafana/dashboards/rl_metrics.json
@@ -1,0 +1,453 @@
+{
+  "__inputs": [],
+  "annotations": {
+    "list": []
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "id": null,
+  "links": [],
+  "panels": [],
+  "refresh": "10s",
+  "rows": [
+    {
+      "collapse": false,
+      "editable": true,
+      "height": "250px",
+      "panels": [
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 1,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 4,
+          "targets": [
+            {
+              "expr": "rate(rl_training_reward_summary_sum[1m]) / rate(rl_training_reward_summary_count[1m])",
+              "query": "rate(rl_training_reward_summary_sum[1m]) / rate(rl_training_reward_summary_count[1m])",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "avg reward",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Episode Reward Average",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 2,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 4,
+          "targets": [
+            {
+              "expr": "rate(rl_training_episode_length_summary_sum[1m]) / rate(rl_training_episode_length_summary_count[1m])",
+              "query": "rate(rl_training_episode_length_summary_sum[1m]) / rate(rl_training_episode_length_summary_count[1m])",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "avg length",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Episode Length Average",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        },
+        {
+          "cacheTimeout": null,
+          "datasource": "Prometheus",
+          "description": null,
+          "editable": true,
+          "error": false,
+          "fieldConfig": {
+            "defaults": {
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": ""
+            }
+          },
+          "height": null,
+          "gridPos": null,
+          "hideTimeOverride": false,
+          "id": 3,
+          "interval": null,
+          "links": [],
+          "maxDataPoints": 100,
+          "minSpan": null,
+          "repeat": null,
+          "repeatDirection": null,
+          "maxPerRow": null,
+          "span": 4,
+          "targets": [
+            {
+              "expr": "rl_training_episodes_total",
+              "query": "rl_training_episodes_total",
+              "target": "",
+              "format": "time_series",
+              "hide": false,
+              "interval": "",
+              "intervalFactor": 2,
+              "legendFormat": "episodes",
+              "metric": "",
+              "refId": "",
+              "step": 10,
+              "instant": false,
+              "datasource": null
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "Episodes Processed",
+          "transparent": false,
+          "transformations": [],
+          "aliasColors": {},
+          "bars": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "isNew": true,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false,
+            "alignAsTable": false,
+            "hideEmpty": false,
+            "hideZero": false,
+            "rightSide": false,
+            "sideWidth": null,
+            "sort": null,
+            "sortDesc": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "nullPointMode": "connected",
+          "options": {
+            "dataLinks": [],
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "stack": false,
+          "steppedLine": false,
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "thresholds": [],
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "name": null,
+            "values": [],
+            "show": true
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "decimals": null,
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": 0
+          }
+        }
+      ],
+      "showTitle": false,
+      "title": "New row",
+      "repeat": null
+    }
+  ],
+  "schemaVersion": 12,
+  "sharedCrosshair": false,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "title": "RL Episode Metrics",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ],
+    "nowDelay": null,
+    "hidden": false
+  },
+  "timezone": "utc",
+  "version": 0,
+  "uid": null
+}

--- a/grafana/rl_metrics_dashboard.py
+++ b/grafana/rl_metrics_dashboard.py
@@ -1,0 +1,30 @@
+from grafanalib.core import Dashboard, Graph, Row, Target
+
+RL_METRICS_DASHBOARD = Dashboard(
+    title="RL Episode Metrics",
+    rows=[
+        Row(panels=[
+            Graph(
+                title="Episode Reward Average",
+                dataSource="Prometheus",
+                targets=[Target(expr="rate(rl_training_reward_summary_sum[1m]) / rate(rl_training_reward_summary_count[1m])", legendFormat="avg reward")],
+            ),
+            Graph(
+                title="Episode Length Average",
+                dataSource="Prometheus",
+                targets=[Target(expr="rate(rl_training_episode_length_summary_sum[1m]) / rate(rl_training_episode_length_summary_count[1m])", legendFormat="avg length")],
+            ),
+            Graph(
+                title="Episodes Processed",
+                dataSource="Prometheus",
+                targets=[Target(expr="rl_training_episodes_total", legendFormat="episodes")],
+            ),
+        ])
+    ],
+).auto_panel_ids()
+
+if __name__ == "__main__":
+    import json
+    from grafanalib._gen import DashboardEncoder
+
+    print(json.dumps(RL_METRICS_DASHBOARD.to_json_data(), indent=2, cls=DashboardEncoder))

--- a/scripts/update_dashboards.py
+++ b/scripts/update_dashboards.py
@@ -7,6 +7,7 @@ from grafanalib._gen import DashboardEncoder
 from grafana.dashboard import DASHBOARD
 from grafana.observer_dashboard import OBSERVER_DASHBOARD
 from grafana.rl_training_dashboard import RL_TRAINING_DASHBOARD
+from grafana.rl_metrics_dashboard import RL_METRICS_DASHBOARD
 from grafana.plugin_analytics_dashboard import PLUGIN_ANALYTICS_DASHBOARD
 
 
@@ -22,6 +23,7 @@ def main() -> None:
     write_dashboard(DASHBOARD, OUTPUT_DIR / "improvement-dashboard.json")
     write_dashboard(OBSERVER_DASHBOARD, OUTPUT_DIR / "observer-dashboard.json")
     write_dashboard(RL_TRAINING_DASHBOARD, OUTPUT_DIR / "rl_training.json")
+    write_dashboard(RL_METRICS_DASHBOARD, OUTPUT_DIR / "rl_metrics.json")
     write_dashboard(PLUGIN_ANALYTICS_DASHBOARD, OUTPUT_DIR / "plugin_analytics.json")
     print("Dashboards updated")
 


### PR DESCRIPTION
## Summary
- expose episode statistics via Prometheus in `vision.training`
- create a Grafana dashboard for RL metrics
- update the dashboard generation script
- document how to import the new dashboard

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_687237e6fc14832aadf5f4f8e4850ae9