### PR TITLE
Add python-afl fuzzing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,3 +159,34 @@ EOF
           curl -X POST -H 'Content-type: application/json' \
             --data '{"text":"CI failed for ${{ github.repository }} at ${{ github.sha }}"}' \
             "$SLACK_WEBHOOK_URL"
+
+  fuzz:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y afl++
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.lock
+          pip install python-afl
+      - name: Run AFL fuzzing
+        run: |
+          mkdir -p seeds outputs
+          cp tests/fuzz/inputs/manifest.json seeds/
+          afl-fuzz -i seeds -o outputs -V 30 -- python tests/fuzz/plugin_executor_fuzz.py
+      - name: Check for crashes
+        run: |
+          crashes="$(ls outputs/default/crashes 2>/dev/null | grep -v README || true)"
+          if [ -n "$crashes" ]; then
+            echo "Crashes detected: $crashes"
+            exit 1
+          fi

--- a/requirements.lock
+++ b/requirements.lock
@@ -103,6 +103,7 @@ opentelemetry-api==1.34.1
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-grpc
     #   opentelemetry-sdk
     #   opentelemetry-semantic-conventions
 opentelemetry-exporter-otlp-proto-common==1.34.1
@@ -115,6 +116,7 @@ opentelemetry-instrumentation==0.55b1
     # via
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-grpc
 opentelemetry-instrumentation-asgi==0.55b1
     # via opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-fastapi==0.55b1
@@ -135,6 +137,7 @@ opentelemetry-semantic-conventions==0.55b1
     #   opentelemetry-instrumentation
     #   opentelemetry-instrumentation-asgi
     #   opentelemetry-instrumentation-fastapi
+    #   opentelemetry-instrumentation-grpc
     #   opentelemetry-sdk
 opentelemetry-util-http==0.55b1
     # via
@@ -177,6 +180,8 @@ pygments==2.19.1
 pylint==3.3.7
     # via -r requirements.txt
 pytest==8.4.1
+    # via -r requirements.txt
+python-afl==0.7.3
     # via -r requirements.txt
 pyyaml==6.0.2
     # via
@@ -248,7 +253,9 @@ uvicorn==0.35.0
 wily==1.25.0
     # via -r requirements.txt
 wrapt==1.17.2
-    # via opentelemetry-instrumentation
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-grpc
 zipp==3.23.0
     # via importlib-metadata
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ protobuf>=5.0,<6.0                  # protocol buffers for gRPC
 ariadne==0.26.2                     # GraphQL server library
 sentry-sdk==2.32.0                  # error reporting
 pika==1.3.2                         # RabbitMQ client
+python-afl==0.7.3

--- a/tests/fuzz/inputs/manifest.json
+++ b/tests/fuzz/inputs/manifest.json
@@ -1,0 +1,1 @@
+{"id":"demo","name":"demo","version":"0.1","permissions":[]}

--- a/tests/fuzz/plugin_executor_fuzz.py
+++ b/tests/fuzz/plugin_executor_fuzz.py
@@ -1,0 +1,33 @@
+import sys
+import shutil
+from pathlib import Path
+
+import afl
+
+from plugins.executor import run_plugin
+
+
+def fuzz_one(data: bytes) -> None:
+    tmp = Path("/tmp/afl_plugin")
+    if tmp.exists():
+        shutil.rmtree(tmp)
+    tmp.mkdir(parents=True)
+    (tmp / "plugin.py").write_text("print('ok')")
+    try:
+        (tmp / "manifest.json").write_bytes(data)
+        run_plugin(tmp)
+    except Exception:
+        pass
+
+
+def main() -> None:
+    afl.init()
+    while afl.loop():
+        data = sys.stdin.buffer.read()
+        if not data:
+            break
+        fuzz_one(data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- integrate python-afl fuzzing for plugin runtime
- run AFL fuzzing in CI for 30 seconds and fail on crash
- add python-afl dependency

## Testing
- `pytest tests/test_plugin_executor.py --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68723b521e9c832aae943a62a753b441