### PR TITLE
Add feature vector encoder for reflector

### DIFF
--- a/reflector/__init__.py
+++ b/reflector/__init__.py
@@ -2,5 +2,6 @@
 
 from .rl import ReplayBuffer, PPOAgent
 from .state_builder import StateBuilder
+from .feature_vector import from_path as feature_vector
 
-__all__ = ["ReplayBuffer", "PPOAgent", "StateBuilder"]
+__all__ = ["ReplayBuffer", "PPOAgent", "StateBuilder", "feature_vector"]

--- a/reflector/feature_vector.py
+++ b/reflector/feature_vector.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+"""Helpers for generating feature vectors from observability metrics."""
+
+from pathlib import Path
+from typing import List
+
+from core.observability import MetricsProvider
+
+
+def from_path(metrics_path: Path) -> List[float]:
+    """Return a feature vector using metrics from ``metrics_path``."""
+    provider = MetricsProvider(metrics_path)
+    metrics = provider.collect()
+    numeric = {
+        k: float(v)
+        for k, v in metrics.items()
+        if isinstance(v, (int, float))
+    }
+    return [numeric[k] for k in sorted(numeric.keys())]

--- a/tests/test_feature_vector.py
+++ b/tests/test_feature_vector.py
@@ -1,0 +1,8 @@
+from reflector import feature_vector
+
+
+def test_feature_vector_from_metrics(tmp_path):
+    metrics_file = tmp_path / "metrics.json"
+    metrics_file.write_text('{"b": 2, "a": 1, "text": "ignore"}')
+    vec = feature_vector(metrics_file)
+    assert vec == [1.0, 2.0]


### PR DESCRIPTION
## Summary
- compute feature vectors from collected metrics
- expose `feature_vector` helper in `reflector` package
- cover new behaviour with tests

## Testing
- `pytest --maxfail=1 --disable-warnings -q tests/test_feature_vector.py`

------
https://chatgpt.com/codex/tasks/task_e_6872745991a0832aa1e7b8bcec2b4ddc