### PR TITLE
Update RL rewards with test success ratio

### DIFF
--- a/reflector/rl/reward.py
+++ b/reflector/rl/reward.py
@@ -40,13 +40,27 @@ def reward_terms(metrics: Dict[str, float]) -> Dict[str, float]:
     style_keys = ("style", "style_score")
 
     correctness = 0.0
-    for key in correctness_keys:
-        if key in metrics:
-            try:
-                correctness = float(metrics[key])
-            except Exception:
-                correctness = 1.0 if metrics[key] else 0.0
-            break
+    # Prefer explicit test pass metrics if available
+    if "tests_passed" in metrics and "tests_total" in metrics:
+        try:
+            total = float(metrics["tests_total"])
+            correctness = float(metrics["tests_passed"]) / (total or 1.0)
+        except Exception:
+            correctness = 0.0
+    elif "tests_passed" in metrics and "tests_failed" in metrics:
+        try:
+            total = float(metrics["tests_passed"]) + float(metrics["tests_failed"])
+            correctness = float(metrics["tests_passed"]) / (total or 1.0)
+        except Exception:
+            correctness = 0.0
+    else:
+        for key in correctness_keys:
+            if key in metrics:
+                try:
+                    correctness = float(metrics[key])
+                except Exception:
+                    correctness = 1.0 if metrics[key] else 0.0
+                break
 
     performance = 0.0
     for key in runtime_keys:

--- a/tests/test_rl_reward.py
+++ b/tests/test_rl_reward.py
@@ -22,3 +22,11 @@ def test_configured_weights(tmp_path, monkeypatch):
     metrics = {"success": 1, "runtime": 2, "style_score": 1}
     reward, _ = calculate_reward(metrics)
     assert reward == 2 * 1 + 0.1 * -2 + 0
+
+
+def test_test_success_with_runtime():
+    metrics = {"tests_passed": 9, "tests_failed": 1, "runtime": 2}
+    reward, terms = calculate_reward(metrics, weights={"correctness": 1, "performance": 1})
+    assert terms["correctness"] == 0.9
+    assert terms["performance"] == -2
+    assert reward == 0.9 - 2


### PR DESCRIPTION
## Summary
- incorporate test results in RL reward calculation
- test that new metrics interact with runtime performance

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6872ded0456c832a88344d53af75bfa3