### PR TITLE
Add periodic PPO hyperparam mutation strategy

### DIFF
--- a/reflector/rl/__init__.py
+++ b/reflector/rl/__init__.py
@@ -7,7 +7,13 @@ from .models.critic_network import CriticNetwork
 from .ewc import EWC
 from .gen_actions import ActionGenerator
 from .reward import calculate_reward, reward_terms, DEFAULT_WEIGHTS
-from .evolution import HyperParams, EvolutionEnvironment, HyperParamEvolution
+from ..state_builder import StateBuilder
+from .evolution import (
+    HyperParams,
+    EvolutionEnvironment,
+    HyperParamEvolution,
+    PeriodicHyperParamMutation,
+)
 
 __all__ = [
     "ReplayBuffer",
@@ -22,4 +28,6 @@ __all__ = [
     "HyperParams",
     "EvolutionEnvironment",
     "HyperParamEvolution",
+    "PeriodicHyperParamMutation",
+    "StateBuilder",
 ]

--- a/reflector/rl/evolution.py
+++ b/reflector/rl/evolution.py
@@ -190,9 +190,27 @@ class EvolutionStrategyOptimizer:
         return best
 
 
+@dataclass
+class PeriodicHyperParamMutation:
+    """Periodically mutate PPO hyperparameters using an optimizer."""
+
+    optimizer: EvolutionStrategyOptimizer
+    period: int = 10
+    params: HyperParams = field(default_factory=HyperParams)
+    _step: int = field(default=0, init=False, repr=False)
+
+    def step(self) -> HyperParams:
+        """Mutate hyperparameters every ``period`` calls."""
+        self._step += 1
+        if self._step % self.period == 0:
+            self.params = self.optimizer.evolve(self.params)
+        return self.params
+
+
 __all__ = [
     "HyperParams",
     "EvolutionEnvironment",
     "HyperParamEvolution",
     "EvolutionStrategyOptimizer",
+    "PeriodicHyperParamMutation",
 ]

--- a/tests/test_es_optimizer.py
+++ b/tests/test_es_optimizer.py
@@ -1,5 +1,11 @@
 from core.observability import MetricsProvider
-from reflector.rl.evolution import HyperParams, EvolutionEnvironment, EvolutionStrategyOptimizer
+import random
+from reflector.rl.evolution import (
+    HyperParams,
+    EvolutionEnvironment,
+    EvolutionStrategyOptimizer,
+    PeriodicHyperParamMutation,
+)
 
 
 def test_es_optimizer(tmp_path):
@@ -11,4 +17,24 @@ def test_es_optimizer(tmp_path):
     best = es.evolve(HyperParams())
     assert isinstance(best, HyperParams)
     assert es.history
+
+
+def test_periodic_mutation(tmp_path):
+    metrics_file = tmp_path / "metrics.json"
+    metrics_file.write_text("{}")
+    provider = MetricsProvider(metrics_file)
+
+    class DummyEnv(EvolutionEnvironment):
+        def evaluate(self, params: HyperParams) -> float:
+            return params.actor_lr
+
+    env = DummyEnv(metrics_provider=provider, episodes=1)
+    optimizer = EvolutionStrategyOptimizer(environment=env, generations=1)
+    scheduler = PeriodicHyperParamMutation(optimizer=optimizer, period=2)
+    random.seed(0)
+    first = scheduler.params
+    scheduler.step()
+    second = scheduler.step()
+    assert scheduler.params != first
+    assert second == scheduler.params
 


### PR DESCRIPTION
## Summary
- export `StateBuilder` from `reflector.rl`
- implement `PeriodicHyperParamMutation` to mutate PPO hyperparameters on a schedule
- expose new helper via package `__all__`
- test periodic mutation logic

## Testing
- `pytest tests/test_es_optimizer.py tests/test_epo.py tests/test_two_speed_training.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6872e65ed4fc832aaf7c48d338fdbc79