### PR TITLE
Add CICD simulator and metrics tests

### DIFF
--- a/core/cicd_simulator.py
+++ b/core/cicd_simulator.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Dict, Any, Optional
+import random
+
+from .observability import MetricsProvider
+from .production_simulator import SimulationMetricsProvider
+
+
+@dataclass
+class BuildJob:
+    """A CI/CD job with a risk of failure."""
+
+    risk: float = 0.1
+
+
+class CICDSimulator:
+    """Minimal CI/CD pipeline simulator."""
+
+    def __init__(
+        self,
+        metrics_provider: Optional[MetricsProvider] = None,
+        seed: Optional[int] = None,
+    ) -> None:
+        self.metrics_provider = metrics_provider
+        self.random = random.Random(seed)
+        self.queue: List[BuildJob] = []
+        self._metrics: Dict[str, Any] = {
+            "queued_jobs": 0,
+            "successful_builds": 0,
+            "failed_builds": 0,
+        }
+        self._seed = seed
+
+    # --------------------------------------------------------------
+    def reset(self) -> None:
+        self.random = random.Random(self._seed)
+        self.queue.clear()
+        self._metrics = {
+            "queued_jobs": 0,
+            "successful_builds": 0,
+            "failed_builds": 0,
+        }
+
+    # --------------------------------------------------------------
+    def add_job(self, job: Optional[BuildJob] = None) -> None:
+        self.queue.append(job or BuildJob())
+        self._metrics["queued_jobs"] = len(self.queue)
+
+    # --------------------------------------------------------------
+    def step(self, action: Dict[str, Any]) -> Dict[str, Any]:
+        agents = action.get("agents", 1)
+        for _ in range(min(agents, len(self.queue))):
+            job = self.queue.pop(0)
+            if self.random.random() < job.risk:
+                self._metrics["failed_builds"] += 1
+            else:
+                self._metrics["successful_builds"] += 1
+        self._metrics["queued_jobs"] = len(self.queue)
+        metrics = self.collect_metrics()
+        if self.metrics_provider and not isinstance(self.metrics_provider, SimulationMetricsProvider):
+            metrics.update(self.metrics_provider.collect())
+        return {"metrics": metrics}
+
+    # --------------------------------------------------------------
+    def collect_metrics(self) -> Dict[str, Any]:
+        return dict(self._metrics)

--- a/tests/test_cicd_simulator.py
+++ b/tests/test_cicd_simulator.py
@@ -1,0 +1,11 @@
+from core.cicd_simulator import CICDSimulator, BuildJob
+
+
+def test_cicd_simulator_step():
+    sim = CICDSimulator()
+    sim.add_job(BuildJob(risk=0.0))
+    result = sim.step({})
+    metrics = result["metrics"]
+    assert metrics["successful_builds"] == 1
+    assert metrics["queued_jobs"] == 0
+

--- a/tests/test_reflector_simulated_metrics.py
+++ b/tests/test_reflector_simulated_metrics.py
@@ -1,0 +1,62 @@
+import yaml
+
+from core.reflector import Reflector
+from core.production_simulator import (
+    ProductionSimulator,
+    Service,
+    Database,
+    LoadBalancer,
+    SimulationMetricsProvider,
+)
+from core.cicd_simulator import CICDSimulator, BuildJob
+from core.observability import MetricsProvider
+
+
+class CombinedProvider(MetricsProvider):
+    def __init__(self, prod: ProductionSimulator, cicd: CICDSimulator):
+        super().__init__(metrics_path=None)
+        self.prod = prod
+        self.cicd = cicd
+
+    def collect(self):
+        metrics = {}
+        metrics.update(self.prod.collect_metrics())
+        metrics.update(self.cicd.collect_metrics())
+        total_builds = metrics.get("successful_builds", 0) + metrics.get("failed_builds", 0)
+        if total_builds:
+            metrics["coverage"] = metrics["successful_builds"] / total_builds * 100
+        else:
+            metrics["coverage"] = 100
+        metrics["dependency_health"] = "outdated" if metrics.get("events_processed", 0) else "healthy"
+        metrics["complexity_history"] = [10, 20]
+        return metrics
+
+
+def test_reflector_decisions_with_simulated_metrics(tmp_path):
+    workload = tmp_path / "workload.json"
+    workload.write_text('[{"service": "api", "database": "db"}]')
+    prod = ProductionSimulator(workload_path=workload)
+    prod.add_service(Service(name="api", capacity=1))
+    prod.add_database(Database(name="db", max_connections=1))
+    prod.add_load_balancer(LoadBalancer(name="lb", targets=[prod.services["api"]]))
+    prod.step({})
+
+    cicd = CICDSimulator()
+    cicd.add_job(BuildJob(risk=1.0))
+    cicd.step({})
+
+    provider = CombinedProvider(prod, cicd)
+
+    tasks_file = tmp_path / "tasks.yml"
+    tasks_file.write_text(
+        "- id: 1\n  description: base\n  component: core\n  dependencies: []\n  priority: 1\n  status: pending\n"
+    )
+    code_file = tmp_path / "code.py"
+    code_file.write_text("def foo():\n    return 1\n")
+    tasks = yaml.safe_load(tasks_file.read_text())
+
+    refl = Reflector(tasks_path=tasks_file, analysis_paths=[code_file], metrics_provider=provider)
+    analysis = refl.analyze()
+    decisions = refl.decide(analysis, tasks)
+    assert any(d.get("reason") == "Low test coverage" for d in decisions["process_improvements"])
+    assert any(d.get("reason") == "outdated_dependencies" for d in decisions["architectural_improvements"])


### PR DESCRIPTION
## Summary
- create `CICDSimulator` to mimic a pipeline
- expose a simple test for the new simulator
- test reflector decisions using simulated CI/CD and production metrics

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_6872ede6d954832a8c4f87a430682401