### PR TITLE
Implement simulator output integration in outer loop

### DIFF
--- a/vision/epo/simulation.py
+++ b/vision/epo/simulation.py
@@ -55,7 +55,11 @@ class SimulationEnvironment:
         agent = self.build_agent(gene)
         total = 0.0
         for _ in range(self.episodes):
-            metrics = self.metrics_provider.collect()
+            if self.simulator:
+                step = self.simulator.step({})
+                metrics = step.get("metrics", {})
+            else:
+                metrics = self.metrics_provider.collect()
             agent.train(metrics)
             reward, _terms = calculate_reward(metrics)
             total += reward


### PR DESCRIPTION
## Summary
- integrate ProductionSimulator step metrics into SimulationEnvironment
- verify step usage with new CountingSimulator test

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6872fde9ca20832aa2db4e773ea777d6