### PR TITLE
Add reference plugins docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ python plugins/cli.py \
   upload plugins/example_plugin
 ```
 
+For reference implementations see [docs/plugins/reference_plugins.md](docs/plugins/reference_plugins.md).
+
 ### Security CI Pipeline
 
 The CI workflow performs automated security checks on every push:

--- a/docs/plugins/reference_plugins.md
+++ b/docs/plugins/reference_plugins.md
@@ -1,0 +1,29 @@
+# Reference Plugins
+
+The plugin marketplace includes sample plugins used for testing and documentation purposes.
+These reference plugins demonstrate how a manifest and `plugin.py` should be structured.
+
+## Example Plugin
+
+Located in [`plugins/example_plugin`](../../plugins/example_plugin), this minimal
+plugin prints a short message when executed. It requires only the `read_files`
+permission and has no external dependencies.
+
+## Tech Debt Analyzer
+
+[`plugins/tech_debt_analyzer`](../../plugins/tech_debt_analyzer) provides a small
+utility that runs the built-in `SelfAuditor` against a target directory to
+calculate code complexity metrics. It illustrates how plugins can leverage the
+core modules while remaining sandboxed.
+
+## Packaging and Uploading
+
+Use `plugins/cli.py` to validate and package any plugin directory:
+
+```bash
+python plugins/cli.py validate plugins/tech_debt_analyzer
+python plugins/cli.py package plugins/tech_debt_analyzer
+```
+
+The resulting archive in `dist/` can be signed and uploaded to the marketplace
+with the `upload` command when a service endpoint is available.

--- a/tasks.yml
+++ b/tasks.yml
@@ -404,7 +404,7 @@
   - 73
   - 75
   priority: 3
-  status: pending
+  status: done
   area: plugins
   actionable_steps: []
   acceptance_criteria: []


### PR DESCRIPTION
## Summary
- mark plugin task complete
- document example and tech debt analyzer plugins
- link to reference docs from README

## Testing
- `pytest tests/test_plugin_security.py -q --maxfail=1 --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_687313be655c832a9537fd7a3c1090ec