### PR TITLE
feat(rl): configurable mini-batch updates

### DIFF
--- a/reflector/rl/ppo_agent.py
+++ b/reflector/rl/ppo_agent.py
@@ -25,6 +25,7 @@ class PPOAgent:
     ewc: Optional[EWC] = None
     gamma: float = 0.99
     clip_epsilon: float = 0.2
+    update_batch_size: int = 4
     action_gen: Optional[ActionGenerator] = None
     last_batch: list = field(default_factory=list)
 
@@ -49,7 +50,10 @@ class PPOAgent:
     ) -> None:
         self.replay_buffer.add((state, action, reward, next_state, done, log_prob))
 
-    def update(self, batch_size: int = 4) -> None:
+    def update(self, batch_size: Optional[int] = None) -> None:
+        """Update policy and value networks."""
+        if batch_size is None:
+            batch_size = self.update_batch_size
         batch = self.replay_buffer.sample(batch_size)
         if not batch:
             return

--- a/reflector/rl/training.py
+++ b/reflector/rl/training.py
@@ -22,6 +22,7 @@ class PPOAgent:
     ewc: Optional[EWC] = None
     gamma: float = 0.99
     learning_rate: float = 0.01
+    update_batch_size: int = 4
     action_gen: Optional[ActionGenerator] = None
     policy: Dict[str, float] = field(default_factory=dict)
     last_batch: list = field(default_factory=list)
@@ -39,7 +40,7 @@ class PPOAgent:
         reward, _terms = calculate_reward(metrics)
         action, log_prob = self.select_action(state)
         self.replay_buffer.add((state, action, reward, state, True, log_prob))
-        batch = self.replay_buffer.sample(batch_size=4)
+        batch = self.replay_buffer.sample(batch_size=self.update_batch_size)
         if not batch:
             return
         self.last_batch = batch

--- a/vision/ppo/agent.py
+++ b/vision/ppo/agent.py
@@ -21,6 +21,7 @@ class PPOAgent:
     gamma: float = 0.99
     learning_rate: float = 0.01
     clip_epsilon: float = 0.2
+    update_batch_size: int = 4
     policy: Dict[str, float] = field(default_factory=dict)
     value: Dict[str, float] = field(default_factory=dict)
     last_batch: list = field(default_factory=list)
@@ -47,7 +48,10 @@ class PPOAgent:
     def value_estimate(self, state: Dict[str, float]) -> float:
         return sum(state.get(k, 0.0) * self.value.get(k, 0.0) for k in state.keys())
 
-    def update(self, batch_size: int = 4) -> None:
+    def update(self, batch_size: Optional[int] = None) -> None:
+        """Update policy/value using sampled experiences."""
+        if batch_size is None:
+            batch_size = self.update_batch_size
         batch = self.replay_buffer.sample(batch_size)
         if not batch:
             return


### PR DESCRIPTION
## Summary
- allow PPO agents to specify `update_batch_size`
- use the configurable batch size in policy updates

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6873249e57c8832ab64ea8fc0e5dddb6