### PR TITLE
Add early adopter outreach program

### DIFF
--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -20,3 +20,7 @@ SelfArchitectAI tracks CHAOSS metrics such as Time to First Response and Contrib
 ## Growing Authority
 
 As the reinforcement learning systems demonstrate reliable performance improvements, project maintainers may gradually increase the RL agent's authority in automating tasks. Major changes will always be announced and open for community feedback before deployment.
+
+## Early Adopter Program
+
+Developers interested in shaping AI-SWA can join the [early adopter outreach program](early_adopter_program.md). This initiative coordinates Reddit and newsletter outreach and provides a direct feedback channel for early users.

--- a/docs/community/early_adopter_program.md
+++ b/docs/community/early_adopter_program.md
@@ -1,0 +1,21 @@
+# Early Adopter Outreach Program
+
+This document outlines how AI-SWA will engage with early adopters and gather actionable feedback.
+
+## Goals
+- Build a small but active group of developers who test AI-SWA in real projects.
+- Collect feedback on usability, documentation gaps, and desired features.
+- Grow initial awareness within key developer communities.
+
+## Outreach Channels
+- **Reddit**: Participate in discussions in r/LLMDevs, r/AIAGENTSNEWS, and related subreddits.
+- **dev.to**: Publish technical articles introducing AI-SWA and showcasing example workflows.
+- **Newsletters**: Pitch short tutorials or project updates to "Ben's Bites" and "AlphaSignal" once the 1.0 release is near.
+
+## Getting Involved
+1. Star the [GitHub repository](https://github.com/adrianwedd/AI-SWA) and open an issue with the `early-adopter` label.
+2. Join our Discord server (invite posted in the repository README) to chat with maintainers.
+3. Share your use cases and feature requests so we can prioritize improvements.
+
+## Feedback Loop
+Early adopters are encouraged to file issues or pull requests describing their experience. The team reviews this feedback during weekly planning sessions and updates the roadmap accordingly.

--- a/tasks.yml
+++ b/tasks.yml
@@ -491,10 +491,14 @@
   dependencies:
   - 90
   priority: 3
-  status: pending
+  status: done
   area: community
-  actionable_steps: []
-  acceptance_criteria: []
+  actionable_steps:
+  - Create docs/community/early_adopter_program.md outlining outreach channels
+  - Link the program from docs/community/README.md
+  acceptance_criteria:
+  - Early adopter guide is present in the repository
+  - README references the early adopter program
   assigned_to: null
   epic: Legacy
 - id: 96


### PR DESCRIPTION
## Summary
- add outreach program for early adopters
- link the new guide in the community README
- close the pending community task

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6873375ee724832a8f02b7db0e0351ad