### PR TITLE
Add threshold gating for RL automation

### DIFF
--- a/tasks.yml
+++ b/tasks.yml
@@ -1598,6 +1598,7 @@
   actionable_steps:
     - Implement safeguards and monitoring for automated actions.
     - Roll out authority incrementally based on shadow mode results.
+    - Gate automated actions behind success thresholds observed in shadow runs.
   dependencies: [165, 175]
   acceptance_criteria:
     - Agent actions can be enabled with human override.


### PR DESCRIPTION
## Summary
- mention gating automated actions behind shadow-run success thresholds

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: HTTPConnectionPool - connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68733a2b7704832a993c855ac0ed7410