### PR TITLE
Implement patch scoring stage

### DIFF
--- a/core/evaluator.py
+++ b/core/evaluator.py
@@ -8,10 +8,15 @@ import yaml
 
 
 class Evaluator:
-    """Provide lightweight scoring and reflection for tasks."""
+    """Provide lightweight scoring and reflection for tasks and patches."""
 
-    def __init__(self, log_path: Path = Path("critiques.yml")) -> None:
+    def __init__(
+        self,
+        log_path: Path = Path("critiques.yml"),
+        patch_log: Path | None = None,
+    ) -> None:
         self.log_path = Path(log_path)
+        self.patch_log = Path(patch_log) if patch_log else Path("patch_scores.yml")
 
     # ------------------------------------------------------------------
     def critique(self, item: Dict[str, Any]) -> Dict[str, Any]:
@@ -50,4 +55,49 @@ class Evaluator:
         for k, v in critiques.items():
             data[str(k)] = v
         with self.log_path.open("w") as fh:
+            yaml.safe_dump(data, fh, sort_keys=False)
+
+    # ------------------------------------------------------------------
+    def critique_patch(self, patch: str) -> Dict[str, Any]:
+        """Return a simple score for a unified diff ``patch``."""
+
+        score = 10
+        notes: List[str] = []
+
+        lines = patch.splitlines()
+        if len(lines) > 50:
+            score -= 2
+            notes.append("large patch")
+
+        normalized = patch.lower()
+        if "todo" in normalized:
+            score -= 2
+            notes.append("todo present")
+        if "print(" in normalized or "debug" in normalized:
+            score -= 1
+            notes.append("debug code")
+
+        return {"score": max(0, score), "notes": "; ".join(notes)}
+
+    # ------------------------------------------------------------------
+    def score_patches(self, patches: List[str]) -> Dict[int, Dict[str, Any]]:
+        """Score each patch and persist the results."""
+
+        results = {idx: self.critique_patch(p) for idx, p in enumerate(patches, 1)}
+        self._save_patch_scores(results)
+        return results
+
+    # ------------------------------------------------------------------
+    def _load_patch_scores(self) -> Dict[str, Dict[str, Any]]:
+        if not self.patch_log.exists():
+            return {}
+        with self.patch_log.open("r") as fh:
+            return yaml.safe_load(fh) or {}
+
+    # ------------------------------------------------------------------
+    def _save_patch_scores(self, scores: Dict[int, Dict[str, Any]]) -> None:
+        data = self._load_patch_scores()
+        for idx, result in scores.items():
+            data[str(idx)] = result
+        with self.patch_log.open("w") as fh:
             yaml.safe_dump(data, fh, sort_keys=False)

--- a/docs/evaluator_workflow.md
+++ b/docs/evaluator_workflow.md
@@ -3,7 +3,8 @@
 The Evaluator scores completed tasks and stores short critiques in
 `critiques.yml`. Each task receives a numeric score and optional notes.
 The Reflector and Planner can later consult these critiques when
-prioritising work.
+prioritising work. Generated patches are also reviewed in a secondary
+stage. Patch scores are written to `patch_scores.yml` for later analysis.
 
 During memory reconciliation the `Memory.reconcile_tasks` method accepts
 these scores to decide which version of a task to keep if multiple

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -13,3 +13,15 @@ def test_critique_scoring(tmp_path):
     assert "1" in data
 
 
+def test_patch_scoring(tmp_path):
+    log = tmp_path / "c.yml"
+    patch_log = tmp_path / "p.yml"
+    ev = Evaluator(log, patch_log=patch_log)
+    patch = """diff --git a/file.py b/file.py\n+print('debug')\n"""
+    result = ev.critique_patch(patch)
+    assert result["score"] < 10
+    ev.score_patches([patch])
+    data = yaml.safe_load(patch_log.read_text())
+    assert "1" in data
+
+


### PR DESCRIPTION
## Summary
- extend `Evaluator` to log patch scores
- document secondary patch review stage
- test patch scoring

## Testing
- `pytest tests/test_evaluator.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68733f17ea34832ab25dec6a061d45ed