### PR TITLE
Implement vector search across docs and tasks

### DIFF
--- a/tests/test_researcher_tasks.py
+++ b/tests/test_researcher_tasks.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import yaml
+
+from core.researcher import Researcher
+
+
+def test_search_across_docs_and_tasks(tmp_path: Path) -> None:
+    docs = tmp_path / "docs"
+    docs.mkdir()
+    (docs / "intro.md").write_text("vector search introduction")
+
+    tasks_file = tmp_path / "tasks.yml"
+    tasks = [
+        {"id": 1, "description": "implement vector search", "dependencies": [], "priority": 1, "status": "done"},
+    ]
+    tasks_file.write_text(yaml.safe_dump(tasks))
+
+    r = Researcher(docs_path=[docs], tasks_files=[tasks_file])
+    results = [name for name, _ in r.search("vector search")]
+    assert any("intro.md" in n for n in results)
+    assert any("tasks.yml:1" in n for n in results)


### PR DESCRIPTION
## Summary
- extend `Researcher` to index documentation directories and task files
- add tests for searching docs and prior tasks

## Testing
- `OTEL_SDK_DISABLED=true pytest tests/test_researcher_tasks.py -q`
- `OTEL_SDK_DISABLED=true pytest --maxfail=1 --disable-warnings -q` *(fails: KeyboardInterrupt after all tests pass)*

------
https://chatgpt.com/codex/tasks/task_e_687356024d40832aaaf27dcf72285be1