### PR TITLE
Centralize config imports across services

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -277,7 +277,7 @@ flowchart TD
     ApplyEnv --> Ready[Return merged config]
 ```
 
-Configuration is loaded with `core.config.load_config()` which merges
+Configuration is loaded with `config.load_config()` which merges
 `config.yaml` with any environment overrides. See the
 [README Configuration](README.md#configuration) section for the list of
 available variables.

--- a/docs/observability/dynamic_config.md
+++ b/docs/observability/dynamic_config.md
@@ -1,6 +1,6 @@
 # Dynamic Configuration Reload
 
-SelfArchitectAI services watch `config.yaml` for changes using `core.config.reload_config()`.
+SelfArchitectAI services watch `config.yaml` for changes using `config.reload_config()`.
 Send a `SIGHUP` signal to any service to trigger a reload without restarting.
 
 ## Usage

--- a/plugins/executor.py
+++ b/plugins/executor.py
@@ -5,7 +5,7 @@ import subprocess
 import shlex
 from pathlib import Path
 
-from core.config import load_config
+from config import load_config
 from core.tool_runner import ToolRunner
 from core.plugins import load_manifest
 

--- a/reflector/rl/reward.py
+++ b/reflector/rl/reward.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, Tuple
 
-from core.config import load_config
+from config import load_config
 
 # Default weights for each reward component
 DEFAULT_WEIGHTS = {

--- a/services/orchestrator_api.py
+++ b/services/orchestrator_api.py
@@ -11,7 +11,7 @@ from typing import Optional
 from fastapi import FastAPI, HTTPException, Depends
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
-from core.config import load_config, reload_config
+from config import load_config, reload_config
 from core.security import verify_api_key, require_role, User
 from core.telemetry import setup_telemetry
 


### PR DESCRIPTION
## Summary
- use repository-level `config` module in plugin executor, RL reward, and orchestrator API
- update docs to reference `config` loader

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68737ec7e2cc832a9e115bae7512bb62