### PR TITLE
Expand RL prioritization tests

### DIFF
--- a/tests/test_rl_training.py
+++ b/tests/test_rl_training.py
@@ -1,4 +1,5 @@
 import json
+from reflector.rl.reward import calculate_reward
 
 from core.observability import MetricsProvider
 from vision.vision_engine import RLAgent
@@ -75,3 +76,15 @@ def test_rl_trainer_records_replay_buffer(tmp_path):
     state, reward = buffer.sample(1)[0]
     assert isinstance(state, dict)
     assert isinstance(reward, float)
+
+def test_rl_agent_train_logs_and_terms(tmp_path):
+    log_file = tmp_path / "log.json"
+    agent = RLAgent(training_path=log_file)
+    metrics = {"success": 1, "runtime": 5}
+    expected_reward, terms = calculate_reward(metrics)
+    reward = agent.train(metrics)
+    assert reward == expected_reward
+    assert agent.last_reward_terms == terms
+    assert agent.training_data[0] == metrics
+    assert json.loads(log_file.read_text().strip()) == metrics
+

--- a/tests/vision/test_hyper_heuristic.py
+++ b/tests/vision/test_hyper_heuristic.py
@@ -43,3 +43,12 @@ class TestHyperHeuristicAgent(unittest.TestCase):
         self.assertIn("baseline", data)
         log_file.unlink()
 
+    def test_training_updates_weights(self):
+        agent = RLHyperHeuristicAgent(exploration=0)
+        metrics = {"gain": 0.5, "success": 1}
+        start = agent.heuristic_weights["wsjf"]
+        reward = agent.train(metrics)
+        self.assertGreaterEqual(reward, 0.0)
+        self.assertAlmostEqual(agent.heuristic_weights["wsjf"], start + 0.05)
+        self.assertEqual(agent.training_data[0], metrics)
+

--- a/tests/vision/test_vision_engine.py
+++ b/tests/vision/test_vision_engine.py
@@ -115,3 +115,19 @@ class TestVisionEngine(unittest.TestCase):
         agent.update_authority(0.95)
         self.assertLessEqual(agent.authority, 1.0)
 
+
+    def test_rl_no_authority_records_history(self):
+        class ReverseAgent(RLAgent):
+            def suggest(self, tasks):
+                return list(reversed(tasks))
+
+        agent = ReverseAgent()
+        ve = VisionEngine(rl_agent=agent, shadow_mode=False)
+        agent.authority = 0.0
+        t1 = self._task(1, 2, 1, 0, 1)
+        t2 = self._task(2, 1, 0, 0, 1)
+        ordered = ve.prioritize([t1, t2])
+        self.assertEqual([t.id for t in ordered], [1, 2])
+        self.assertEqual(len(agent.history), 1)
+        self.assertEqual(agent.history[0]["suggestion"], [2, 1])
+


### PR DESCRIPTION
## Summary
- add regression tests for VisionEngine RL fallback when authority is zero
- cover RLHyperHeuristicAgent training logic
- verify RLAgent.train records reward terms and persists metrics

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68738fa1ee98832a998c43b741eefaa2