### PR TITLE
Complete sentinel policy enforcement review

### DIFF
--- a/docs/reviews/task_136_sentinel.md
+++ b/docs/reviews/task_136_sentinel.md
@@ -5,3 +5,9 @@ listed `blocked_actions`.
 
 - Run the orchestrator with a policy that lists a known task ID.
 - Ensure the task is skipped and a log entry indicates the block.
+
+## Review Results
+
+- Policy file `policy_test.json` blocked task `block` as expected.
+- Orchestrator logged "Action 'block' blocked by policy." to `audit_test.log`.
+- Executor was not invoked.

--- a/tasks.yml
+++ b/tasks.yml
@@ -994,7 +994,7 @@
   dependencies:
   - 136
   priority: 3
-  status: pending
+  status: done
   area: review
   actionable_steps:
   - Run orchestrator with a policy blocking a sample task


### PR DESCRIPTION
## Summary
- document results of Ethical Sentinel policy blocking
- mark review task 141 done in `tasks.yml`

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6874302a713c832abf27e15515c8877c