### PR TITLE
Expand RL prioritization tests

### DIFF
--- a/tests/vision/test_hyper_heuristic.py
+++ b/tests/vision/test_hyper_heuristic.py
@@ -1,6 +1,7 @@
 import unittest
 from pathlib import Path
 import json
+from unittest.mock import patch
 
 from core.task import Task
 from vision import VisionEngine, RLHyperHeuristicAgent
@@ -51,4 +52,12 @@ class TestHyperHeuristicAgent(unittest.TestCase):
         self.assertGreaterEqual(reward, 0.0)
         self.assertAlmostEqual(agent.heuristic_weights["wsjf"], start + 0.05)
         self.assertEqual(agent.training_data[0], metrics)
+
+    def test_exploration_noise_changes_order(self):
+        agent = RLHyperHeuristicAgent(exploration=1.0)
+        t1 = self._task(1, 5, 5, 0, 10)
+        t2 = self._task(2, 5, 5, 0, 10)
+        with patch("vision.hyper_heuristic.random.random", side_effect=[0.1, 0.9]):
+            ordered = agent.suggest([t1, t2])
+        self.assertEqual([t.id for t in ordered], [2, 1])
 

--- a/tests/vision/test_vision_engine.py
+++ b/tests/vision/test_vision_engine.py
@@ -131,3 +131,26 @@ class TestVisionEngine(unittest.TestCase):
         self.assertEqual(len(agent.history), 1)
         self.assertEqual(agent.history[0]["suggestion"], [2, 1])
 
+    def test_rl_partial_authority_no_history(self):
+        class ReverseAgent(RLAgent):
+            def suggest(self, tasks):
+                return list(reversed(tasks))
+
+        agent = ReverseAgent()
+        agent.authority = 0.6
+        ve = VisionEngine(rl_agent=agent, shadow_mode=False)
+        t1 = self._task(1, 1, 1, 1, 1)
+        t2 = self._task(2, 1, 1, 1, 1)
+        ordered = ve.prioritize([t1, t2])
+        self.assertEqual([t.id for t in ordered], [2, 1])
+        self.assertEqual(agent.history, [])
+
+    def test_rl_update_authority_threshold_and_cap(self):
+        agent = RLAgent()
+        agent.update_authority(0.05)  # equal to threshold
+        self.assertEqual(agent.authority, 0.0)
+        agent.update_authority(0.9)
+        self.assertAlmostEqual(agent.authority, 0.9)
+        agent.update_authority(0.5)
+        self.assertEqual(agent.authority, 1.0)
+


### PR DESCRIPTION
## Summary
- add exploration noise test for RLHyperHeuristicAgent
- add partial authority and threshold tests for VisionEngine/RLAgent

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68743f37270c832a8e480bbe88dd5b2a