### PR TITLE
Document docker requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Planner decides what to build next. The Executor writes files and configures CI/
    health checks.
    If you want to enable the optional Rust optimizations, run `maturin develop`
    inside the `rust_ext` directory before starting the compose stack.
+   
+   **Note:** Docker must be available for this step. In restricted environments
+   where the Docker daemon cannot start (such as some online sandboxes), the
+   compose stack will fail to run. You can still execute unit tests by
+   installing dependencies directly or by using the [VS Code Dev
+   Container](docs/deployment/devcontainer.md), but the full workflow with all
+   services will be skipped.
 8. **Run End-to-End Tests**
    ```bash
    pytest tests/e2e/ --maxfail=1 --disable-warnings -q

--- a/docs/deployment/devcontainer.md
+++ b/docs/deployment/devcontainer.md
@@ -3,6 +3,10 @@
 The repository ships a ready to use [Dev Container](https://code.visualstudio.com/docs/devcontainers/containers) definition.
 It provides a consistent environment with Python 3.12 and the required extensions installed.
 
+This container is especially useful when Docker is not available for running the
+full `docker-compose` workflow. Opening the repository in the Dev Container lets
+you install dependencies and run tests without needing a local Docker daemon.
+
 ## Quick start
 
 1. Install the **Dev Containers** extension for VS Code.


### PR DESCRIPTION
## Summary
- mention Docker requirement for the compose workflow
- explain that the VS Code devcontainer can run tests when Docker isn't available

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6874439386f4832a8346eb7d84ec4ee8