### PR TITLE
Fix help text for orchestrator CLI

### DIFF
--- a/core/cli.py
+++ b/core/cli.py
@@ -42,7 +42,10 @@ def _queue_length(tasks_file: str) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     """Return argument parser for the CLI."""
-    parser = argparse.ArgumentParser(description="SelfArchitectAI orchestration CLI")
+    parser = argparse.ArgumentParser(
+        description="SelfArchitectAI orchestration CLI",
+        prog="python -m ai_swa.orchestrator",
+    )
     parser.add_argument(
         "--config",
         default="config.yaml",


### PR DESCRIPTION
## Summary
- show `python -m ai_swa.orchestrator` in CLI usage output

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_6874eaa17b70832a8aff020194f04c5a