### PR TITLE
Preserve task metadata in orchestrator

### DIFF
--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -425,6 +425,21 @@ class TestOrchestrator(unittest.TestCase):
             with self.assertRaises(KeyError):
                 self.orchestrator.run("tasks.yml")
 
+    def test_items_to_tasks_and_back_preserves_metadata(self):
+        item = {
+            "id": 1,
+            "description": "demo",
+            "dependencies": [],
+            "priority": 1,
+            "status": "pending",
+            "extra": "field",
+        }
+        tasks = self.orchestrator._items_to_tasks([item])
+        self.assertEqual(tasks[0].metadata, {"extra": "field"})
+        out = self.orchestrator._task_to_dict(tasks[0])
+        self.assertIn("extra", out)
+        self.assertEqual(out["extra"], "field")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- use dataclasses' fields when converting tasks to dicts and back
- ensure orchestrator keeps additional task fields round-trip
- test preservation of extra metadata

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: opentelemetry exporter connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_687505ccb9bc832abe81d802a1eea618