### PR TITLE
Summarize RL vs WSJF testing

### DIFF
--- a/docs/research/RL_vs_WSJF_Test_Report.md
+++ b/docs/research/RL_vs_WSJF_Test_Report.md
@@ -7,3 +7,15 @@ The test executes the Vision Engine twice:
 2. With a simple RL agent that reverses the task order and runs with full authority.
 
 The RL run produces a different ordering and records the comparison in a history file. This confirms that RL-driven prioritization can diverge from the baseline and that the logging mechanism works.
+
+Example ordering from the integration test:
+- WSJF baseline order: ``[2, 1, 3]`` with scores ``[3.5, 2.6, 2.0]``
+- RL refined order: ``[3, 1, 2]`` with scores ``[2.0, 2.6, 3.5]``
+
+## Additional Test Coverage
+
+The RL training suite (`tests/test_rl_training.py`) ensures that metrics collected during
+experiment runs are persisted for offline analysis. It also verifies that rewards are
+calculated correctly and that replay buffers receive recorded samples. All tests pass,
+confirming that the RL agent integrates with the observability layer.
+


### PR DESCRIPTION
## Summary
- capture RL vs WSJF integration results in research doc
- highlight RL training coverage confirming metrics persistence and reward logging

## Testing
- `pytest tests/test_rl_vs_wsjf_integration.py tests/test_rl_training.py -q`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_68750d9ffea0832aaa5b4f09c051b67d