### PR TITLE
Add drift analysis report and follow-up tasks

### DIFF
--- a/docs/reports/drift_analysis_report.md
+++ b/docs/reports/drift_analysis_report.md
@@ -1,0 +1,37 @@
+# Drift Analysis Report
+
+## Drift Analysis
+- **Stale Success Criteria** – The README states the project succeeds when the main branch contains exactly one commit. The repository now has hundreds of commits. This is unacknowledged drift.
+- **Protocol Alignment** – Agents generally follow the Iterative Development Protocol, but some tasks remain pending for long periods.
+- **Self‑Evolution Emphasis** – Architecture docs and code implement evolutionary components, aligning with the vision of self‑improvement.
+- **Unclear Boundary on Node Integration** – Cross-language support exists, but orchestration details remain vague, hinting at scope creep.
+- **Governance and Ethics** – Policy framework and Ethical Sentinel are present and match governance goals.
+- **CI Security Additions** – Recent tasks add SCA, SAST, sandbox testing, and signing steps in CI.
+
+## Decision Audit Ledger
+1. **CI Pipeline Hardening** – Origin: Task 135 SEC-001. Adds automated vetting and signing steps.
+2. **Vision Engine RL vs WSJF Comparison** – Origin: Task 139 and related research.
+3. **Node-Based IO Service** – Origin: README and architecture docs. Provides gRPC interface.
+4. **Ethical Sentinel Policy Framework** – Origin: Governance tasks. Enforces responsible AI behavior.
+5. **Evolutionary Policy Optimizer** – Origin: Two-Speed Reflector architecture doc.
+
+## Trajectory Assessment
+1. **Converging on Robust Self-Evolution** – Integration of RL prioritization, plugin certification, and ethical policies leads to mature autonomous development.
+2. **Orbiting in Feature Bloat** – Expansion into Rust, Node, and complex CI may cause bloat if not pruned.
+3. **Diverging into Fragmentation** – Cross-language services could drift without cohesive governance.
+
+## Schema & Structural Integrity Checks
+- `tasks.yml` conforms to its JSON schema.
+- Governance files specify policy creation and validation steps.
+- Repository layout matches architecture documentation.
+
+## Recommendations for Realignment
+1. **Update Success Criteria** – Revise README to reflect multi-commit workflow.
+2. **Reduce Task Backlog Entropy** – Archive or reprioritize long-pending tasks.
+3. **Clarify Cross-Language Strategy** – Provide a roadmap for Node and Rust components.
+4. **Automate Policy Refresh** – Ensure Ethical Sentinel policies are dynamically loaded.
+5. **Document Evolution Loop Outcomes** – Summarize results from RL and evolutionary components regularly.
+
+## Scores
+- **Narrative Intelligence Score:** 76/100
+- **Agentic Harmony Score:** 72/100

--- a/tasks.yml
+++ b/tasks.yml
@@ -2154,3 +2154,69 @@
   acceptance_criteria:
     - Orchestrator runs without AttributeError from self_auditor.
   epic: Testing Improvements
+- id: 220
+  title: Update README success criteria
+  description: Reflect multi-commit workflow and CI gating in the README success section.
+  area: docs
+  dependencies: []
+  priority: 3
+  status: pending
+  actionable_steps:
+    - Modify README to describe current success metrics based on CI and tasks.
+    - Remove reference to single-commit history.
+  acceptance_criteria:
+    - README no longer states that main has one commit.
+    - Updated criteria mention passing CI and completed tasks.
+  epic: Governance
+- id: 221
+  title: Reprioritize and archive stale tasks
+  description: Review long-pending tasks and either close, update, or archive them to reduce backlog entropy.
+  area: process
+  dependencies: []
+  priority: 3
+  status: pending
+  actionable_steps:
+    - Identify tasks pending for over three months.
+    - Decide whether to archive or reprioritize each.
+  acceptance_criteria:
+    - Backlog contains only active and relevant tasks.
+  epic: Governance
+- id: 222
+  title: Clarify cross-language roadmap
+  description: Provide a concise roadmap for Node and Rust components to prevent uncontrolled scope expansion.
+  area: microservices
+  dependencies: []
+  priority: 2
+  status: pending
+  actionable_steps:
+    - Summarize current Node and Rust usage in docs.
+    - Outline criteria for adding new services in other languages.
+  acceptance_criteria:
+    - A roadmap document exists in docs/architecture or README.
+  epic: Architecture Evolution
+- id: 223
+  title: Automate Ethical Sentinel policy refresh
+  description: Ensure policies are loaded dynamically and tested to stay current.
+  area: governance
+  dependencies: []
+  priority: 2
+  status: pending
+  actionable_steps:
+    - Add policy reload logic to the sentinel.
+    - Write tests confirming updates take effect without restart.
+  acceptance_criteria:
+    - Policies can be updated on disk and loaded at runtime.
+  epic: Governance
+- id: 224
+  title: Document evolution loop outcomes
+  description: Regularly summarize results from RL and evolutionary components.
+  area: reflector
+  dependencies: []
+  priority: 2
+  status: pending
+  actionable_steps:
+    - Create periodic report template for RL experiments.
+    - Publish results after each cycle in docs/reports.
+  acceptance_criteria:
+    - At least one report is added summarizing recent evolution loop results.
+  epic: Reflector Core


### PR DESCRIPTION
## Summary
- document recent drift analysis in `docs/reports`
- add tasks to address recommendations

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError for opentelemetry instrumentation and other missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687892ed84ac832a858a69bf660956ea