### PR TITLE
Add cross-language guideline doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ Planner decides what to build next. The Executor writes files and configures CI/
    The `orchestrator-api` service exposes equivalent REST endpoints
    (`/start`, `/stop`, `/status`) when running under Docker Compose.
 5. **Explore the Blueprint** – Open `ARCHITECTURE.md` to see components and dependency rationales.
-6. **Watch It Evolve** – Each execution may introduce new tasks or propose refactors. Review and merge the generated commit.
-7. **Run with Docker Compose**
+6. **Read Cross-Language Guidelines** – See [cross_language_guidelines.md](docs/architecture/cross_language_guidelines.md) for how Python, Rust and Node services interact.
+7. **Watch It Evolve** – Each execution may introduce new tasks or propose refactors. Review and merge the generated commit.
+8. **Run with Docker Compose**
    ```bash
    docker-compose up --build
    ```
@@ -103,7 +104,7 @@ Planner decides what to build next. The Executor writes files and configures CI/
    installing dependencies directly or by using the [VS Code Dev
    Container](docs/deployment/devcontainer.md), but the full workflow with all
    services will be skipped.
-8. **Run End-to-End Tests**
+9. **Run End-to-End Tests**
    ```bash
    pytest tests/e2e/ --maxfail=1 --disable-warnings -q
    ```

--- a/docs/architecture/cross_language_guidelines.md
+++ b/docs/architecture/cross_language_guidelines.md
@@ -1,0 +1,28 @@
+# Cross-Language Guidelines
+
+This document summarizes how AI-SWA combines Python with Rust and Node.js as outlined in [RB-004](../../research/RB-004_Cross_Language_Design.md). The aim is to keep each component in the language best suited for its workload while maintaining clear boundaries.
+
+## Component Boundaries
+
+- **Python** – Primary language for the Orchestrator, Planner, Worker and plugin governance. Chosen for rapid iteration and scripting flexibility.
+- **Rust** – Used for CPU-bound performance hotspots. Services like `rust_bridge` and future extensions built with PyO3 accelerate heavy analysis routines.
+- **Node.js** – Runs I/O-heavy tasks. The `IOService` and future real-time dashboards operate as separate Node services communicating via gRPC.
+
+These boundaries follow the phased roadmap described in the Polyglot Microservices Strategy.
+
+## FFI Type-Safety Guidelines
+
+1. Expose Rust functions through `PyO3` with explicit types and `PyResult` error handling.
+2. Avoid `unsafe` blocks in shared modules. If unavoidable, cover them with Python-side tests.
+3. Validate all data crossing language boundaries and convert to concrete structs instead of using raw pointers.
+4. Integrate Node.js via gRPC rather than in-process bindings to maintain isolation and type safety.
+5. Regenerate gRPC stubs from `.proto` definitions whenever they change to keep bindings consistent.
+
+## Multi-Language CI Strategy
+
+- Execute `pytest` for Python, `cargo test` for Rust and `npm test` with `npm audit` for Node services.
+- Apply shared GitHub Actions templates so every service performs dependency scanning (pip-audit, cargo-audit, npm audit).
+- Build Docker images for each service and run integration tests starting the Python core plus all foreign services.
+- The workflow fails if any language's tests or security checks do not pass.
+
+Following these practices ensures the small set of languages remains manageable while providing the performance and concurrency benefits explored in RB-004.

--- a/tasks.yml
+++ b/tasks.yml
@@ -2187,7 +2187,7 @@
   area: microservices
   dependencies: []
   priority: 2
-  status: pending
+  status: done
   actionable_steps:
     - Summarize current Node and Rust usage in docs.
     - Outline criteria for adding new services in other languages.
@@ -2252,7 +2252,7 @@
   area: microservices
   dependencies: [222]
   priority: 2
-  status: pending
+  status: done
   actionable_steps:
     - Draft docs/architecture/cross_language_guidelines.md.
     - Outline data contract and build tooling expectations.


### PR DESCRIPTION
## Summary
- outline Python/Rust/Node boundaries and FFI tips
- link new guidelines from README
- mark cross-language tasks complete

## Testing
- `pip install -r requirements.lock`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: failed to connect to remote host)*

------
https://chatgpt.com/codex/tasks/task_e_687acd766084832aa4437dc44251223f