### PR TITLE
Add Sentinel escalation documentation

### DIFF
--- a/docs/governance/sentinel_escalation.md
+++ b/docs/governance/sentinel_escalation.md
@@ -1,0 +1,27 @@
+# Ethical Sentinel Escalation Workflow
+
+Research Brief [RB-007](../../research/RB-007_Ethical_Sentinel.md) outlines open questions around automated policy enforcement, escalation, and privacy. This document summarizes how those questions are addressed in the current platform.
+
+## Automated Policy Check Pipeline
+
+1. **Static Policy Catalog** – JSON policy files under `policies/` define blocked action IDs. The [EthicalSentinel](../../core/sentinel.py) loads these files at runtime and rejects tasks that match `blocked_actions`.
+2. **CI Enforcement** – The CI workflow runs unit tests to validate new or updated policies against `policy_schema.json` and exercises Sentinel logic. Builds fail when policies contain schema errors or disallowed behavior.
+3. **Dynamic Reload** – Policies are loaded lazily so updates take effect on the next run of the orchestrator. This supports rapid experimentation while retaining a single source of truth.
+
+## Human Escalation Paths
+
+When the Sentinel blocks a task or detects anomalous behavior it cannot automatically resolve, it triggers the two-stage AI Incident Response Plan (AI‑IRP):
+
+1. **Automated Containment** – High‑severity violations cause the Sentinel to halt the offending agent, revoke credentials and log the incident.
+2. **Human Review** – The incident is escalated to the AI‑IRP response team consisting of an Incident Manager, Technical Lead, Legal Counsel, Communications Manager and Ethics Officer. They analyze the logs, perform deeper containment and coordinate public or internal disclosures as needed.
+
+Escalation severity follows the Incident Severity and Response Matrix described in the Sentinel research blueprint. Low‑impact events are logged for later review, while critical incidents page the full response team immediately.
+
+## Balancing Privacy with Observability
+
+RB‑007 identifies the challenge of providing system visibility without exposing sensitive data. The Sentinel employs privacy‑enhancing technologies:
+
+- **Differential Privacy** adds calibrated noise to telemetry so trends can be detected without revealing individual actions.
+- **Federated Learning** aggregates local monitoring models on each agent, sharing only anonymized updates with the Sentinel.
+
+This architecture allows continuous policy enforcement and anomaly detection while preserving user data confidentiality.


### PR DESCRIPTION
## Summary
- document how the Ethical Sentinel loads policies, triggers the AI-IRP and balances privacy
- clarify escalation path referencing RB-007 research

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad633d0c4832a95ab62684be7669f