### PR TITLE
Update reward metrics for RL

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -35,3 +35,4 @@ reward:
   correctness: 1.0
   performance: 0.5
   style: 0.2
+  complexity: 0.2

--- a/reflector/rl/reward.py
+++ b/reflector/rl/reward.py
@@ -11,6 +11,7 @@ DEFAULT_WEIGHTS = {
     "correctness": 1.0,
     "performance": 0.5,
     "style": 0.2,
+    "complexity": 0.2,
 }
 
 
@@ -31,13 +32,17 @@ def get_weights() -> Dict[str, float]:
 def reward_terms(metrics: Dict[str, float]) -> Dict[str, float]:
     """Extract reward components from ``metrics``.
 
+    Components include:
+
     - ``correctness`` derives from ``success`` or ``task_success``.
     - ``performance`` is the negative runtime or duration.
-    - ``style`` uses ``style`` or ``style_score`` metrics.
+    - ``style`` uses ``style``/``style_score`` or ``lint_score`` metrics.
+    - ``complexity`` is taken from ``complexity`` or ``complexity_score``.
     """
     correctness_keys = ("correctness", "success", "task_success")
     runtime_keys = ("runtime", "duration")
-    style_keys = ("style", "style_score")
+    style_keys = ("style", "style_score", "lint_score")
+    complexity_keys = ("complexity", "complexity_score")
 
     correctness = 0.0
     # Prefer explicit test pass metrics if available
@@ -80,10 +85,20 @@ def reward_terms(metrics: Dict[str, float]) -> Dict[str, float]:
                 style = 0.0
             break
 
+    complexity = 0.0
+    for key in complexity_keys:
+        if key in metrics:
+            try:
+                complexity = float(metrics[key])
+            except Exception:
+                complexity = 0.0
+            break
+
     return {
         "correctness": correctness,
         "performance": performance,
         "style": style,
+        "complexity": complexity,
     }
 
 

--- a/tests/test_rl_reward.py
+++ b/tests/test_rl_reward.py
@@ -2,26 +2,53 @@ from reflector.rl.reward import calculate_reward, reward_terms, DEFAULT_WEIGHTS
 
 
 def test_reward_terms_extraction():
-    metrics = {"success": True, "runtime": 2.0, "style_score": 0.5}
+    metrics = {
+        "success": True,
+        "runtime": 2.0,
+        "style_score": 0.5,
+        "complexity_score": 0.3,
+    }
     terms = reward_terms(metrics)
     assert terms["correctness"] == 1.0
     assert terms["performance"] == -2.0
     assert terms["style"] == 0.5
+    assert terms["complexity"] == 0.3
+
+
+def test_reward_terms_lint_score():
+    metrics = {"success": True, "lint_score": 0.8}
+    terms = reward_terms(metrics)
+    assert terms["style"] == 0.8
 
 
 def test_weighted_reward():
-    metrics = {"success": 1, "runtime": 1, "style_score": 1}
-    reward, _ = calculate_reward(metrics, weights={"correctness": 1, "performance": 1, "style": 1})
-    assert reward == 1 - 1 + 1
+    metrics = {
+        "success": 1,
+        "runtime": 1,
+        "style_score": 1,
+        "complexity_score": 1,
+    }
+    reward, _ = calculate_reward(
+        metrics,
+        weights={"correctness": 1, "performance": 1, "style": 1, "complexity": 1},
+    )
+    assert reward == 1 - 1 + 1 + 1
 
 
 def test_configured_weights(tmp_path, monkeypatch):
     cfg = tmp_path / "config.yaml"
-    cfg.write_text("""reward:\n  correctness: 2\n  performance: 0.1\n  style: 0\n""")
+    cfg.write_text(
+        """reward:\n  correctness: 2\n  performance: 0.1\n  style: 0\n  complexity: 0.5\n"""
+    )
     monkeypatch.setenv("CONFIG_FILE", str(cfg))
-    metrics = {"success": 1, "runtime": 2, "style_score": 1}
+    metrics = {
+        "success": 1,
+        "runtime": 2,
+        "style_score": 1,
+        "complexity_score": 4,
+    }
     reward, _ = calculate_reward(metrics)
-    assert reward == 2 * 1 + 0.1 * -2 + 0
+    assert reward == 2 * 1 + 0.1 * -2 + 0 + 0.5 * 4
 
 
 def test_test_success_with_runtime():


### PR DESCRIPTION
## Summary
- expand RL reward system to include complexity and lint scores
- parse new metrics in reward terms
- adjust config weights for new complexity term
- test coverage for complexity and lint metrics

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce6bdf334832aa39ffed42f8da981