### PR TITLE
Add docstring coverage metric

### DIFF
--- a/reflector/rl/reward.py
+++ b/reflector/rl/reward.py
@@ -12,6 +12,7 @@ DEFAULT_WEIGHTS = {
     "performance": 0.5,
     "style": 0.2,
     "complexity": 0.2,
+    "doc_coverage": 0.1,
 }
 
 
@@ -43,6 +44,7 @@ def reward_terms(metrics: Dict[str, float]) -> Dict[str, float]:
     runtime_keys = ("runtime", "duration")
     style_keys = ("style", "style_score", "lint_score")
     complexity_keys = ("complexity", "complexity_score")
+    doc_keys = ("doc_coverage", "docs_coverage")
 
     correctness = 0.0
     # Prefer explicit test pass metrics if available
@@ -94,11 +96,21 @@ def reward_terms(metrics: Dict[str, float]) -> Dict[str, float]:
                 complexity = 0.0
             break
 
+    doc_cov = 0.0
+    for key in doc_keys:
+        if key in metrics:
+            try:
+                doc_cov = float(metrics[key])
+            except Exception:
+                doc_cov = 0.0
+            break
+
     return {
         "correctness": correctness,
         "performance": performance,
         "style": style,
         "complexity": complexity,
+        "doc_coverage": doc_cov,
     }
 
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -35,9 +35,10 @@ def test_docs_agent_generates_report(tmp_path):
     sample = tmp_path / "sample.py"
     sample.write_text("def foo():\n    pass\n")
     agent = DocsAgent(targets=[str(tmp_path)], report_dir=tmp_path)
-    reports = agent.run()
+    reports, coverage = agent.run()
     assert (tmp_path / "docstring.log").exists()
     assert reports
+    assert 0.0 <= coverage <= 1.0
 
 
 def test_supervisor_dispatch():

--- a/tests/test_rl_reward.py
+++ b/tests/test_rl_reward.py
@@ -7,12 +7,14 @@ def test_reward_terms_extraction():
         "runtime": 2.0,
         "style_score": 0.5,
         "complexity_score": 0.3,
+        "doc_coverage": 0.8,
     }
     terms = reward_terms(metrics)
     assert terms["correctness"] == 1.0
     assert terms["performance"] == -2.0
     assert terms["style"] == 0.5
     assert terms["complexity"] == 0.3
+    assert terms["doc_coverage"] == 0.8
 
 
 def test_reward_terms_lint_score():
@@ -27,12 +29,13 @@ def test_weighted_reward():
         "runtime": 1,
         "style_score": 1,
         "complexity_score": 1,
+        "doc_coverage": 1,
     }
     reward, _ = calculate_reward(
         metrics,
-        weights={"correctness": 1, "performance": 1, "style": 1, "complexity": 1},
+        weights={"correctness": 1, "performance": 1, "style": 1, "complexity": 1, "doc_coverage": 1},
     )
-    assert reward == 1 - 1 + 1 + 1
+    assert reward == 1 - 1 + 1 + 1 + 1
 
 
 def test_configured_weights(tmp_path, monkeypatch):
@@ -57,3 +60,9 @@ def test_test_success_with_runtime():
     assert terms["correctness"] == 0.9
     assert terms["performance"] == -2
     assert reward == 0.9 - 2
+
+
+def test_doc_coverage_term():
+    metrics = {"doc_coverage": 0.6}
+    terms = reward_terms(metrics)
+    assert terms["doc_coverage"] == 0.6


### PR DESCRIPTION
## Summary
- update DocsAgent to compute docstring coverage from pylint output
- propagate doc coverage to PPO training
- track doc_coverage in RL reward calculation
- test updates for doc coverage reporting

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(fails: ModuleNotFoundError: No module named 'grpc')*

------
https://chatgpt.com/codex/tasks/task_e_687ceaec348c832aa716c4e91f8e43ce