### PR TITLE
Add RL reward utilities

### DIFF
--- a/core/rl/__init__.py
+++ b/core/rl/__init__.py
@@ -1,0 +1,10 @@
+"""Reinforcement learning utilities for the core subsystem."""
+
+from .reward import calculate_reward, complexity_penalty, linting_bonus, integration_stability
+
+__all__ = [
+    "calculate_reward",
+    "complexity_penalty",
+    "linting_bonus",
+    "integration_stability",
+]

--- a/core/rl/reward.py
+++ b/core/rl/reward.py
@@ -1,0 +1,96 @@
+"""Reward helpers for code quality and stability.
+
+This module exposes a ``calculate_reward`` API combining three metrics:
+- Complexity penalty computed with ``radon``.
+- Linting bonus using ``pylint``.
+- Integration test stability from provided test results.
+
+Each component returns a floating point value which is summed to obtain the
+final reward.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Mapping
+
+from radon.complexity import cc_visit
+from pylint.lint import Run
+
+
+def complexity_penalty(changeset: Mapping[str, str]) -> float:
+    """Return negative penalty based on cyclomatic complexity.
+
+    ``changeset`` maps filenames to their updated source code. Complexity
+    is averaged across all functions and scaled down to keep magnitudes small.
+    """
+    complexities: list[float] = []
+    for content in changeset.values():
+        try:
+            for item in cc_visit(content):
+                complexities.append(float(item.complexity))
+        except Exception:
+            continue
+    if not complexities:
+        return 0.0
+    avg = sum(complexities) / len(complexities)
+    return -avg / 10.0
+
+
+def linting_bonus(changeset: Mapping[str, str]) -> float:
+    """Return positive bonus based on pylint score for the changed files."""
+    if not changeset:
+        return 0.0
+    with tempfile.TemporaryDirectory() as tmpdir:
+        paths: list[str] = []
+        for name, content in changeset.items():
+            path = Path(tmpdir) / Path(name).name
+            Path(path).write_text(content)
+            paths.append(str(path))
+        try:
+            result = Run(paths, exit=False)
+            score = float(getattr(result.linter.stats, "global_note", 0.0))
+        except Exception:
+            score = 0.0
+    return score / 10.0
+
+
+def integration_stability(results: Mapping[str, float | int]) -> float:
+    """Return integration test pass rate from ``results`` mapping."""
+    if "integration_pass_rate" in results:
+        try:
+            return float(results["integration_pass_rate"])
+        except Exception:
+            return 0.0
+    if "passed" in results and "total" in results:
+        try:
+            total = float(results["total"]) or 1.0
+            return float(results["passed"]) / total
+        except Exception:
+            return 0.0
+    if "passed" in results and "failed" in results:
+        try:
+            total = float(results["passed"]) + float(results["failed"])
+            return float(results["passed"]) / (total or 1.0)
+        except Exception:
+            return 0.0
+    return 0.0
+
+
+def calculate_reward(
+    changeset: Mapping[str, str], test_results: Mapping[str, float | int]
+) -> float:
+    """Return overall reward from lint, complexity and integration metrics."""
+    penalty = complexity_penalty(changeset)
+    bonus = linting_bonus(changeset)
+    stability = integration_stability(test_results)
+    return penalty + bonus + stability
+
+
+__all__ = [
+    "calculate_reward",
+    "complexity_penalty",
+    "linting_bonus",
+    "integration_stability",
+]

--- a/tests/test_core_rl_reward.py
+++ b/tests/test_core_rl_reward.py
@@ -1,0 +1,57 @@
+from core.rl.reward import (
+    calculate_reward,
+    complexity_penalty,
+    linting_bonus,
+    integration_stability,
+)
+
+
+def test_complexity_penalty():
+    simple = {"a.py": "def func():\n    return 1\n"}
+    complex_code = {
+        "b.py": (
+            "def func(x):\n"
+            "    for i in range(x):\n"
+            "        if i % 2 == 0:\n"
+            "            x += i\n"
+            "    return x\n"
+        )
+    }
+    p_simple = complexity_penalty(simple)
+    p_complex = complexity_penalty(complex_code)
+    assert p_complex < p_simple
+
+
+def test_linting_bonus():
+    good = {
+        "good.py": (
+            '"""module"""\n\n'
+            "def good_func():\n"
+            '    """doc"""\n'
+            "    return 1\n"
+        )
+    }
+    bad = {"bad.py": "def bad(x):\n    return x\n"}
+    b_good = linting_bonus(good)
+    b_bad = linting_bonus(bad)
+    assert b_good > b_bad
+
+
+def test_integration_stability():
+    low = {"integration_pass_rate": 0.2}
+    high = {"integration_pass_rate": 0.9}
+    assert integration_stability(high) > integration_stability(low)
+
+
+def test_calculate_reward_aggregation():
+    changeset = {
+        "good.py": (
+            '"""m"""\n\n'
+            "def good_func():\n"
+            '    """doc"""\n'
+            "    return 1\n"
+        )
+    }
+    tests = {"integration_pass_rate": 0.8}
+    reward = calculate_reward(changeset, tests)
+    assert reward > 0


### PR DESCRIPTION
## Summary
- implement `core.rl.reward` with complexity penalty, lint bonus and integration stability
- expose `calculate_reward` API
- test reward components

## Testing
- `pytest tests/test_core_rl_reward.py -q`
- `pytest --maxfail=1 --disable-warnings -q` *(all tests)*

------
https://chatgpt.com/codex/tasks/task_e_687d1706f07c832aa474a2aa3a0d3526