### PR TITLE
Add tasks from gemini-cli and codex analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@ services/node/node_modules/
 dist/
 plugin_marketplace/web/node_modules/
 plugin_marketplace/web/dist/
+
+# local artifacts
+metrics.json
+research/clones/
+sandbox/
+tests/*.db
+tests/*.zip
+*.db

--- a/research/RB-010_External_Repo_Insights.md
+++ b/research/RB-010_External_Repo_Insights.md
@@ -1,0 +1,23 @@
+# Research Brief RB-010: External AI CLI Architectures
+
+This brief documents insights gathered from inspecting two open-source projects: [Gemini CLI](https://github.com/google-gemini/gemini-cli) and [OpenAI Codex](https://github.com/openai/codex). Both provide command-line agents that interface with language models. Their designs help inform potential features for the AI-SWA project.
+
+## Gemini CLI
+- **Stack:** TypeScript/Node.js monorepo using `pnpm` with packages `cli`, `core`, and `vscode-ide-companion`.
+- **CLI package:** Handles user input, manages display themes, and maintains history. Configurable via a rich set of command flags.
+- **Core package:** Orchestrates API calls to Gemini, constructs prompts, and executes tools. Tools live under `packages/core/src/tools/` and include file system and shell helpers.
+- **Interaction flow:** User input flows from the CLI to the core package. The core may call tools (after user confirmation for write operations) and then forwards results back to the CLI for display. The architecture document emphasises modularity and extensibility of tools.
+
+## OpenAI Codex
+- **Stack:** Primarily Rust (`codex-rs`) with a legacy TypeScript CLI. The Rust implementation aims for a zero-dependency install.
+- **AGENTS.md:** Notes that code executes in a sandbox, disallowing network access via a `CODEX_SANDBOX_NETWORK_DISABLED` env variable. Contributors must run `just fmt` and `just fix` before PRs and run `cargo test --all-features`.
+- **Codex Core:** Provides a protocol-driven engine documented in `codex-rs/core` with a newline-delimited JSON protocol for UIs. Concepts include `Session`, `Task`, and `Turn`. The protocol allows sending user input, streaming model responses, executing commands, and applying patches while waiting for user approvals when needed.
+- **CLI packages:** There is a Rust CLI crate invoking the core protocol and a deprecated TypeScript implementation. Configuration is stored in `config.toml` under `$CODEX_HOME` and can also be set via command-line flags.
+
+## Implementation Ideas for AI-SWA
+- **CLI Frontend + Core Backend:** Following Gemini CLI’s separation, AI-SWA could expose a simple CLI package that forwards requests to existing orchestration services, keeping user experience decoupled from backend logic.
+- **Extensible Tool System:** Both projects use a plugin or tool mechanism for environment actions. A similar registry of safe tools would allow users to add file, shell, or network operations with explicit approval steps.
+- **Protocol for Sessions and Tasks:** Codex defines a structured protocol with `Session`, `Task`, and `Turn`, which could inspire a formal message bus for AI-SWA agents and plugins.
+- **Sandbox Controls:** Leveraging Codex’s environment variable approach, AI-SWA could enforce offline/sandbox modes during unit tests or when running in restricted environments.
+
+These patterns demonstrate production-ready approaches to building CLI-driven agents and can guide future enhancements in the AI-SWA architecture.

--- a/tasks.yml
+++ b/tasks.yml
@@ -2482,3 +2482,56 @@
   acceptance_criteria:
     - Audit log captures every policy check and intervention.
   epic: Governance
+- id: 245
+  title: Build CLI Frontend Wrapper
+  description: Implement a lightweight CLI that forwards user commands to the orchestrator service.
+  area: cli
+  dependencies: []
+  priority: 3
+  status: pending
+  actionable_steps:
+    - Create a Python entrypoint under services/cli that parses arguments.
+    - Forward commands to existing orchestrator APIs via HTTP.
+    - Document usage examples in README.
+  acceptance_criteria:
+    - Running `ai-swa` executes commands against the orchestrator.
+  epic: Usability
+- id: 246
+  title: Create Plugin Tool Registry
+  description: Provide a registry for approved tools requiring user confirmation before execution.
+  area: plugins
+  dependencies: []
+  priority: 3
+  status: pending
+  actionable_steps:
+    - Design registry data structure and approval workflow.
+    - Implement hooks for file and shell operations.
+  acceptance_criteria:
+    - Tools cannot execute without prior registration and confirmation.
+  epic: Plugin System
+- id: 247
+  title: Define Session Message Bus Protocol
+  description: Model agent interactions using Session, Task, and Turn messages inspired by Codex.
+  area: architecture
+  dependencies: []
+  priority: 2
+  status: pending
+  actionable_steps:
+    - Draft protocol specification in docs/session_protocol.md.
+    - Implement basic classes in core/message_bus.py.
+  acceptance_criteria:
+    - Agents exchange JSON messages adhering to the protocol.
+  epic: Core Architecture
+- id: 248
+  title: Add Sandbox Mode Environment Variable
+  description: Enforce offline mode when `CODEX_SANDBOX_NETWORK_DISABLED` is set.
+  area: ci
+  dependencies: []
+  priority: 2
+  status: pending
+  actionable_steps:
+    - Respect env variable in network-related modules.
+    - Document behavior in CONTRIBUTING.md.
+  acceptance_criteria:
+    - Tests pass with the environment variable enabled and network calls mocked.
+  epic: Security


### PR DESCRIPTION
## Summary
- document architecture insights from gemini-cli and codex
- track follow-up implementation tasks in `tasks.yml`

## Testing
- `pytest --maxfail=1 --disable-warnings -q` *(interrupted: 86 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_687d2c60a5d8832aa4cb24481f2ece0d