### PR TITLE
Add Claude Code Base workflow

### DIFF
--- a/.github/workflows/claude-base.yml
+++ b/.github/workflows/claude-base.yml
@@ -1,0 +1,15 @@
+name: Claude Code Base Action
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-claude-code:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Claude Code Base Action
+        uses: anthropics/claude-code-base-action@beta
+        with:
+          prompt: "Hello from Claude Code Base Action"
+          allowed_tools: "Bash(git:*),View,GlobTool,GrepTool,BatchTool"
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -267,6 +267,11 @@ Set `SNYK_TOKEN`, `COSIGN_KEY`, and `COSIGN_PASSWORD` secrets to enable these st
 
 See [docs/plugins/certification_pipeline.md](docs/plugins/certification_pipeline.md) for a diagram and explanation of the full vetting process.
 
+### Claude Code Base Workflow
+
+The repository includes a `Claude Code Base Action` workflow located in `.github/workflows/claude-base.yml`. This job runs Anthropic's base action using a manual trigger to experiment with new prompts. Set the `ANTHROPIC_API_KEY` secret to enable it.
+
+
 ## 📈 Observability
 
 All services expose Prometheus-compatible metrics. The Node I/O service uses


### PR DESCRIPTION
## Summary
- add Claude Code Base GitHub workflow
- document the workflow in README

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68807955f0cc832a9a4b68ebe5fbac15